### PR TITLE
Add GoatCounter click tracking to external links

### DIFF
--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -11,33 +11,33 @@
 
 <div class="social-icons">
     {{ with .Site.Params.social.instagram }}
-    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-instagram" aria-label="Instagram">
+    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-instagram" data-goatcounter-click="ext-social-instagram" aria-label="Instagram">
         <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
             <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
         </svg>
     </a>
     {{ end }}
     {{ with .Site.Params.social.facebook }}
-    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-facebook" aria-label="Facebook">
+    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-facebook" data-goatcounter-click="ext-social-facebook" aria-label="Facebook">
         <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
             <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
         </svg>
     </a>
     {{ end }}
     {{ with .Site.Params.social.bluesky }}
-    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-bluesky" aria-label="Bluesky">
+    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-bluesky" data-goatcounter-click="ext-social-bluesky" aria-label="Bluesky">
         <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
             <path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 0 1-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.206-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8Z"/>
         </svg>
     </a>
     {{ end }}
     {{ with .Site.Params.social.ridewithgps }}
-    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-ridewithgps" aria-label="RideWithGPS">
+    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-ridewithgps" data-goatcounter-click="ext-social-ridewithgps" aria-label="RideWithGPS">
         <img src="{{ "images/icons/ridewithgps-white.png" | relURL }}" alt="RideWithGPS" width="24" height="24" class="social-icon-img">
     </a>
     {{ end }}
     {{ with .Site.Params.social.github }}
-    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-github" aria-label="GitHub">
+    <a href="{{ . }}" target="_blank" rel="noopener" data-track="social-github" data-goatcounter-click="ext-social-github" aria-label="GitHub">
         <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
         </svg>
@@ -110,14 +110,14 @@
             {{ with .date }}<span class="link-subtitle">{{ . }}</span>{{ end }}
         </div>
         <div class="event-actions">
-            <a href="{{ .url }}" target="_blank" rel="noopener" class="event-button" data-track="event-{{ .title | urlize }}">
+            <a href="{{ .url }}" target="_blank" rel="noopener" class="event-button" data-track="event-{{ .title | urlize }}" data-goatcounter-click="ext-event-{{ .title | urlize }}">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                     <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
                 </svg>
                 View Event
             </a>
             {{ with .route }}
-            <a href="{{ . }}" target="_blank" rel="noopener" class="route-button" data-track="route-{{ $event.title | urlize }}">
+            <a href="{{ . }}" target="_blank" rel="noopener" class="route-button" data-track="route-{{ $event.title | urlize }}" data-goatcounter-click="ext-route-{{ $event.title | urlize }}">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                     <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
                 </svg>
@@ -167,7 +167,7 @@
 <section class="link-section">
     <h2 class="section-title">Read About Us!</h2>
     {{ range $articles.Params.articles }}
-    <a href="{{ .url }}" target="_blank" rel="noopener" class="link-button" data-track="article-{{ .source | urlize }}">
+    <a href="{{ .url }}" target="_blank" rel="noopener" class="link-button" data-track="article-{{ .source | urlize }}" data-goatcounter-click="ext-article-{{ .source | urlize }}">
         <span class="link-title">{{ .source }}</span>
         {{ with .quote }}<span class="link-subtitle">"{{ . }}"</span>{{ end }}
     </a>


### PR DESCRIPTION
## Summary
This PR adds GoatCounter click tracking attributes to all external links throughout the linkpage theme. This enables better analytics tracking for user interactions with social media links, event links, route links, and article links.

## Changes Made
- Added `data-goatcounter-click` attributes to all social media icon links (Instagram, Facebook, Bluesky, RideWithGPS, GitHub)
- Added `data-goatcounter-click` attributes to event action buttons (View Event and Route links)
- Added `data-goatcounter-click` attributes to article links in the "Read About Us" section
- GoatCounter click event names follow the pattern `ext-{category}-{identifier}` for consistency with existing `data-track` attributes

## Implementation Details
- The GoatCounter tracking attributes use the same identifier patterns as the existing `data-track` attributes for consistency
- All external links now have dual tracking: the original `data-track` attribute and the new `data-goatcounter-click` attribute
- This allows for parallel analytics tracking without breaking existing tracking implementations

https://claude.ai/code/session_01GFKsxWvF6asmcKsoKXZ4nb