### PR TITLE
Add GoatCounter analytics tracking to event share button

### DIFF
--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -124,7 +124,7 @@
                 Route
             </a>
             {{ end }}
-            <button class="share-button" data-event-title="{{ .title }}" data-event-date="{{ .date }}" data-event-url="{{ .url }}" aria-label="Share event">
+            <button class="share-button" data-event-title="{{ .title }}" data-event-date="{{ .date }}" data-event-url="{{ .url }}" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-{{ .title | urlize }}-event-copy-ext-{{ .url }}" aria-label="Share event">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                     <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/>
                 </svg>


### PR DESCRIPTION
## Summary
Added GoatCounter analytics tracking to the share button for upcoming ride events to monitor user engagement with the share functionality.

## Changes
- Added `data-goatcounter-click` attribute to the share button element
- The tracking identifier includes:
  - Site domain (extracted from `$.Site.BaseURL`)
  - Event title (URL-encoded)
  - Static identifier: "event-copy-ext"
  - Event URL for context

## Implementation Details
The GoatCounter click tracking attribute follows the pattern: `{domain}-{event-title}-event-copy-ext-{event-url}`, allowing analytics to distinguish between different events and track share button interactions across the site.

https://claude.ai/code/session_0165Hz3KPo7k9nLmJHygzTE8