### PR TITLE
Add tags to all events for filtering

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -16,18 +16,21 @@ events:
     url: "https://shift2bikes.org/calendar/event-23092"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "1/12 Post-Bike Happy Hour Ride"
     date: "January 12, 2026"
     url: "https://shift2bikes.org/calendar/event-23116"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "1/26 Bike Happy Hour"
     date: "January 26, 2026"
     url: "https://shift2bikes.org/calendar/event-23093"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "1/26 Post-Bike Happy Hour Ride"
     date: "January 26, 2026"
@@ -35,12 +38,14 @@ events:
     #route: "https://ridewithgps.com/routes/12345"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "2/9 Bike Happy Hour"
     date: "February 9, 2026"
     url: "https://shift2bikes.org/calendar/event-23094"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "2/9 Post-Bike Happy Hour Ride"
     date: "February 9, 2026"
@@ -48,12 +53,14 @@ events:
     #route: "https://ridewithgps.com/routes/12345"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "2/23 Bike Happy Hour"
     date: "February 23, 2026"
     url: "https://shift2bikes.org/calendar/event-23095"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "2/23 Post-Bike Happy Hour Ride"
     date: "February 23, 2026"
@@ -61,12 +68,14 @@ events:
     #route: "https://ridewithgps.com/routes/12345"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "3/9 Bike Happy Hour"
     date: "March 9, 2026"
     url: "https://shift2bikes.org/calendar/event-23096"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "3/9 Post-Bike Happy Hour Ride"
     date: "March 9, 2026"
@@ -74,12 +83,14 @@ events:
     #route: "https://ridewithgps.com/routes/12345"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "3/23 Bike Happy Hour"
     date: "March 23, 2026"
     url: "https://shift2bikes.org/calendar/event-23097"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "3/23 Post-Bike Happy Hour Ride"
     date: "March 23, 2026"
@@ -87,349 +98,411 @@ events:
     #route: "https://ridewithgps.com/routes/12345"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "4/13 Bike Happy Hour"
     date: "April 13, 2026"
     url: "https://shift2bikes.org/calendar/event-23098"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "4/13 Post-Bike Happy Hour Ride"
     date: "April 13, 2026"
     url: "https://shift2bikes.org/calendar/event-23122"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "4/27 Bike Happy Hour"
     date: "April 27, 2026"
     url: "https://shift2bikes.org/calendar/event-23099"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "4/27 Post-Bike Happy Hour Ride"
     date: "April 27, 2026"
     url: "https://shift2bikes.org/calendar/event-23123"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "5/2 Beaverton Foodie Bike Ride (not a RWS ride)"
     date: "May 2, 2026"
     url: "https://www.shift2bikes.org/calendar/event-23576"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride, not-rws]
 
   - title: "5/11 Bike Happy Hour"
     date: "May 11, 2026"
     url: "https://shift2bikes.org/calendar/event-23100"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "5/11 Post-Bike Happy Hour Ride"
     date: "May 11, 2026"
     url: "https://shift2bikes.org/calendar/event-23124"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "5/25 Bike Happy Hour"
     date: "May 25, 2026"
     url: "https://shift2bikes.org/calendar/event-23101"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "5/25 Post-Bike Happy Hour Ride"
     date: "May 25, 2026"
     url: "https://shift2bikes.org/calendar/event-23125"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "6/8 Bike Happy Hour"
     date: "June 8, 2026"
     url: "https://shift2bikes.org/calendar/event-23102"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "6/8 Post-Bike Happy Hour Ride"
     date: "June 8, 2026"
     url: "https://shift2bikes.org/calendar/event-23126"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "6/22 Bike Happy Hour"
     date: "June 22, 2026"
     url: "https://shift2bikes.org/calendar/event-23103"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "6/22 Post-Bike Happy Hour Ride"
     date: "June 22, 2026"
     url: "https://shift2bikes.org/calendar/event-23127"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "7/13 Bike Happy Hour"
     date: "July 13, 2026"
     url: "https://shift2bikes.org/calendar/event-23104"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "7/13 Post-Bike Happy Hour Ride"
     date: "July 13, 2026"
     url: "https://shift2bikes.org/calendar/event-23128"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "7/27 Bike Happy Hour"
     date: "July 27, 2026"
     url: "https://shift2bikes.org/calendar/event-23105"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "7/27 Post-Bike Happy Hour Ride"
     date: "July 27, 2026"
     url: "https://shift2bikes.org/calendar/event-23129"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "8/10 Bike Happy Hour"
     date: "August 10, 2026"
     url: "https://shift2bikes.org/calendar/event-23106"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "8/10 Post-Bike Happy Hour Ride"
     date: "August 10, 2026"
     url: "https://shift2bikes.org/calendar/event-23130"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "8/24 Bike Happy Hour"
     date: "August 24, 2026"
     url: "https://shift2bikes.org/calendar/event-23107"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "8/24 Post-Bike Happy Hour Ride"
     date: "August 24, 2026"
     url: "https://shift2bikes.org/calendar/event-23131"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "9/14 Bike Happy Hour"
     date: "September 14, 2026"
     url: "https://shift2bikes.org/calendar/event-23108"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "9/14 Post-Bike Happy Hour Ride"
     date: "September 14, 2026"
     url: "https://shift2bikes.org/calendar/event-23132"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "9/28 Bike Happy Hour"
     date: "September 28, 2026"
     url: "https://shift2bikes.org/calendar/event-23109"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "9/28 Post-Bike Happy Hour Ride"
     date: "September 28, 2026"
     url: "https://shift2bikes.org/calendar/event-23133"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "10/12 Bike Happy Hour"
     date: "October 12, 2026"
     url: "https://shift2bikes.org/calendar/event-23110"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "10/12 Post-Bike Happy Hour Ride"
     date: "October 12, 2026"
     url: "https://shift2bikes.org/calendar/event-23134"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "10/26 Bike Happy Hour"
     date: "October 26, 2026"
     url: "https://shift2bikes.org/calendar/event-23111"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "10/26 Post-Bike Happy Hour Ride"
     date: "October 26, 2026"
     url: "https://shift2bikes.org/calendar/event-23135"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "11/9 Bike Happy Hour"
     date: "November 9, 2026"
     url: "https://shift2bikes.org/calendar/event-23112"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "11/9 Post-Bike Happy Hour Ride"
     date: "November 9, 2026"
     url: "https://shift2bikes.org/calendar/event-23136"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "11/23 Bike Happy Hour"
     date: "November 23, 2026"
     url: "https://shift2bikes.org/calendar/event-23113"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "11/23 Post-Bike Happy Hour Ride"
     date: "November 23, 2026"
     url: "https://shift2bikes.org/calendar/event-23137"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "12/14 Bike Happy Hour"
     date: "December 14, 2026"
     url: "https://shift2bikes.org/calendar/event-23114"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "12/14 Post-Bike Happy Hour Ride"
     date: "December 14, 2026"
     url: "https://shift2bikes.org/calendar/event-23138"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   - title: "12/28 Bike Happy Hour"
     date: "December 28, 2026"
     url: "https://shift2bikes.org/calendar/event-23115"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [happy-hour]
 
   - title: "12/28 Post-Bike Happy Hour Ride"
     date: "December 28, 2026"
     url: "https://shift2bikes.org/calendar/event-23139"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [ride]
 
   # Tigard Happy Hours - 1st and 3rd Tuesdays
   - title: "1/6 Tigard Happy Hour"
     date: "January 6, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "1/20 Tigard Happy Hour"
     date: "January 20, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "2/3 Tigard Happy Hour"
     date: "February 3, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "2/17 Tigard Happy Hour"
     date: "February 17, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "3/3 Tigard Happy Hour"
     date: "March 3, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "3/17 Tigard Happy Hour"
     date: "March 17, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "4/7 Tigard Happy Hour"
     date: "April 7, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "4/21 Tigard Happy Hour"
     date: "April 21, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "5/5 Tigard Happy Hour"
     date: "May 5, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "5/19 Tigard Happy Hour"
     date: "May 19, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "6/2 Tigard Happy Hour"
     date: "June 2, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "6/16 Tigard Happy Hour"
     date: "June 16, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "7/7 Tigard Happy Hour"
     date: "July 7, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "7/21 Tigard Happy Hour"
     date: "July 21, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "8/4 Tigard Happy Hour"
     date: "August 4, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "8/18 Tigard Happy Hour"
     date: "August 18, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "9/1 Tigard Happy Hour"
     date: "September 1, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "9/15 Tigard Happy Hour"
     date: "September 15, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "10/6 Tigard Happy Hour"
     date: "October 6, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "10/20 Tigard Happy Hour"
     date: "October 20, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "11/3 Tigard Happy Hour"
     date: "November 3, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "11/17 Tigard Happy Hour"
     date: "November 17, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "12/1 Tigard Happy Hour"
     date: "December 1, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   - title: "12/15 Tigard Happy Hour"
     date: "December 15, 2026"
     start: "Tigard"
     end: "Tigard"
+    tags: [happy-hour]
 
   # Ride to ride
   - title: "4/11 The Ladds 500 R2R"
@@ -437,6 +510,7 @@ events:
     url: "https://www.shift2bikes.org/calendar/event-23431"
     start: "Beaverton"
     end: "Ladd's Addition"
+    tags: [ride, r2r]
 
   # Causes
   - title: "5/2 Andi's Ride 1 - Supporting a Peer for Mental Health Month"
@@ -444,6 +518,7 @@ events:
     url: "https://www.shift2bikes.org/calendar/event-23669"
     start: "Quatama"
     end: "Quatama"
+    tags: [ride, cause]
 
   # Memes
   - title: "The 67 ride (test)"
@@ -451,7 +526,8 @@ events:
     url: "https://www.shift2bikes.org/calendar/event-23298"
     start: "Beaverton"
     end: "Hillsboro"
-    
+    tags: [ride]
+
   # Critical Mass
   # Festivals
   - title: "Bike Beaverton"
@@ -459,5 +535,6 @@ events:
     url: "https://beavertonoregon.gov/508/Bike-Beaverton-Event"
     start: "Beaverton"
     end: "Beaverton"
+    tags: [festival]
 
 ---


### PR DESCRIPTION
Tags assigned:
- happy-hour: all Beaverton and Tigard Bike Happy Hours (48 events)
- ride: all Post-Bike Happy Hour Rides and other cycling rides (28 events)
- r2r: The Ladds 500 R2R (ride-to-ride)
- cause: Andi's Ride (mental health charity ride)
- not-rws: Beaverton Foodie Bike Ride (external event)
- festival: Bike Beaverton

https://claude.ai/code/session_018bm6uRFNUfeUx5NRSGcxdw