### PR TITLE
Add Beaverton Night Market Bike Bus and Pride in the Park 2026

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -550,6 +550,13 @@ events:
     end: "Portland"
     tags: [festival, ride, not-rws, family-friendly]
 
+  - title: "6/28 Pride Beaverton"
+    date: "June 28, 2026"
+    url: "https://pridebeaverton.org/"
+    start: "Beaverton"
+    end: "Beaverton"
+    tags: [festival, not-rws]
+
   - title: "8/2 North Portland Sunday Parkways"
     date: "August 2, 2026"
     url: "https://www.portland.gov/sunday-parkways/north-event-2026"

--- a/content/events.md
+++ b/content/events.md
@@ -728,4 +728,11 @@ events:
     date: "June 7, 2026"
     tags: [ride]
 
+  - title: "8/8 Beaverton Night Market Bike Bus"
+    date: "August 8, 2026"
+    url: "https://shift2bikes.org/calendar/event-24146"
+    start: "Beaverton"
+    end: "Beaverton"
+    tags: [ride]
+
 ---

--- a/content/events.md
+++ b/content/events.md
@@ -550,12 +550,13 @@ events:
     end: "Portland"
     tags: [festival, ride, not-rws, family-friendly]
 
-  - title: "6/28 Pride Beaverton"
+  - title: "6/28 Pride in the Park 2026"
     date: "June 28, 2026"
     url: "https://pridebeaverton.org/"
     start: "Beaverton"
     end: "Beaverton"
-    tags: [festival, not-rws]
+    start_address: "SW 5th St & SW Hall Blvd, Beaverton, OR 97005"
+    tags: [festival, not-rws, family-friendly]
 
   - title: "8/2 North Portland Sunday Parkways"
     date: "August 2, 2026"
@@ -740,6 +741,6 @@ events:
     url: "https://shift2bikes.org/calendar/event-24146"
     start: "Beaverton"
     end: "Beaverton"
-    tags: [ride]
+    tags: [ride, family-friendly]
 
 ---


### PR DESCRIPTION
## Summary

- **8/8 Beaverton Night Market Bike Bus** — new ride event linking to Shift2Bikes event-24146; route and schedule TBD; tagged `[ride, family-friendly]`; shares the date with Kidical Mass #5 (times may not overlap)
- **6/28 Pride in the Park 2026** — new festival event at Beaverton City Park (SW 5th & Hall), 11am–5pm, free and family-friendly; tagged `[festival, not-rws, family-friendly]`

## Test plan

- [ ] Events appear in the Upcoming Rides section on the site
- [ ] Pride in the Park Navigate button opens Beaverton City Park correctly
- [ ] Night Market Bike Bus View Event button links to the correct Shift2Bikes page
- [ ] Both events show the `family-friendly` chip and respond to tag filtering

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qo5dUXQ7miwKKbJyUW1q2w)_