### PR TITLE
Add draft Jurisdictions and Engagement pages

### DIFF
--- a/content/engagement.md
+++ b/content/engagement.md
@@ -1,0 +1,105 @@
+---
+title: "Get Involved: Westside Civic Engagement"
+description: "Committees, advisory boards, public meetings, and project comment opportunities where westside cyclists can shape better infrastructure."
+draft: true
+---
+
+*This page is a starting draft — meeting schedules, committee names, and application windows change frequently. Please double-check every link and date before sharing.*
+
+Reporting a pothole gets a pothole fixed. Showing up to public meetings and joining advisory committees is how we get *better roads* — protected bike lanes, complete streets, safer crossings, and connected trail networks. The westside has more seats at the table than most people realize, and many of them sit empty.
+
+## Why this matters
+
+Most westside transportation projects are shaped years before the first orange cone shows up. By the time construction starts, the design is locked in. The high-leverage moments are:
+
+- **Transportation System Plan (TSP) updates** — every 5–10 years per jurisdiction
+- **Capital Improvement Plan (CIP) hearings** — usually annual
+- **Project open houses and 30/60/90% design reviews** — project-specific
+- **Advisory committee meetings** — ongoing
+- **City council and county board meetings** — when projects come up for funding or design approval
+
+A handful of cyclists showing up consistently to these has an outsized effect.
+
+## Advisory committees (recurring volunteer roles)
+
+These are the highest-leverage commitments. Most meet monthly, are 2–3 hours, and have appointed seats — you apply, get appointed, and serve a term.
+
+### Washington County Bicycle Advisory Committee (WC BAC)
+Advises the county on bike infrastructure, project priorities, and policy.
+- **Meets**: monthly *(TODO: confirm cadence and location)*
+- **Apply via**: Washington County boards & commissions page *(TODO: confirm URL)*
+- **Website**: <https://www.washingtoncountyor.gov/>
+
+### City Bicycle/Pedestrian Advisory Committees
+Several westside cities have or have had standing BPACs or transportation committees.
+- **City of Beaverton**: *(TODO: confirm whether a standing committee exists currently; in the past has had a Traffic Commission and project-specific committees)*
+- **City of Tigard**: *(TODO: confirm — Tigard has historically had a Transportation Advisory Committee)*
+- **City of Hillsboro**: *(TODO: confirm — Hillsboro has historically had a transportation-related committee)*
+- **City of Tualatin / Sherwood / Forest Grove**: *(TODO)*
+
+### THPRD Advisory Committees
+THPRD operates parks and most regional trails on the urban westside.
+- **Trails Advisory Committee** *(TODO: confirm current name and apply URL)*
+- **Parks & Facilities Advisory Committee** *(TODO)*
+- **Website**: <https://www.thprd.org/>
+
+### Metro JPACT and TPAC
+Regional transportation policy — Joint Policy Advisory Committee on Transportation (elected officials) and Transportation Policy Alternatives Committee (staff & stakeholders). Both take public comment.
+- **Website**: <https://www.oregonmetro.gov/>
+
+### ODOT Region 1 Area Commission on Transportation (R1ACT)
+Advises ODOT Region 1 on state highway priorities for the Portland metro area.
+- **Website**: <https://www.oregon.gov/odot/>
+
+## Public meetings worth showing up to
+
+You don't need an appointed seat to attend or testify at these. Three minutes of public comment from a real cyclist with a real story is surprisingly effective.
+
+- **City council meetings** (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius, etc.) — usually 1–2× per month. Transportation items are typically on the consent agenda or as study sessions.
+- **Washington County Board of Commissioners** — *(TODO: confirm cadence, usually weekly Tuesdays)*
+- **THPRD Board of Directors** — *(TODO: confirm cadence, usually monthly)*
+- **Metro Council** — weekly during session
+- **Project open houses** — watch agency websites and BikePortland for announcements
+
+## Plans and projects to watch
+
+These are the documents and projects that will define westside cycling for the next decade.
+
+- **Washington County 2040 / Transportation System Plan**: *(TODO: confirm current status)*
+- **City TSP updates**: each city updates its TSP on its own cycle — check city websites
+- **Metro Regional Transportation Plan (RTP)**: updated every ~5 years
+- **TV Highway corridor improvements**: ongoing multi-jurisdictional project
+- **OR-217 improvements**: ongoing ODOT project
+- **Westside Trail completion**: gaps in the trail are being closed in phases
+- **Fanno Creek Trail completion**: gaps are being closed in phases
+- **Red Electric Trail**: planned east-west connector through Beaverton
+- **Council Creek Trail**: planned Hillsboro-to-Forest Grove rail trail
+
+*(TODO: this list will go stale fast — review it at least once a year.)*
+
+## Statewide and regional advocacy groups
+
+You don't have to do this alone. Several groups already do the legwork of tracking meetings and producing testimony — joining or following them multiplies your impact.
+
+- **The Street Trust** — <https://thestreettrust.org/>
+- **BikeLoud PDX** — <https://bikeloudpdx.org/>
+- **Oregon Walks** — <https://oregonwalks.org/>
+- **BikePortland** (news and action alerts) — <https://bikeportland.org/>
+
+## How to give effective public comment
+
+- **Two to three minutes is the standard limit.** Practice it out loud.
+- **Lead with your tie to the area** — "I commute by bike from Aloha to downtown Beaverton three days a week."
+- **One specific story beats five general points.** "Last week at Murray and Allen, I was almost right-hooked because…" lands harder than "we need safer streets."
+- **End with a specific ask.** "Please fund the protected bike lane on X in this CIP cycle."
+- **Written testimony counts too** — and it gets into the record verbatim. Email beats voicemail.
+
+## Ways to plug in with Ride Westside
+
+- **Policy rides**: from time to time we host rides with elected officials and decision-makers. Watch the [events list](/) for upcoming ones.
+- **Open-house caravans**: when there's a project open house, we sometimes ride there together. It's more fun and it's a stronger statement to arrive on bikes.
+- **Coordinate testimony**: if you're planning to testify on a project, let us know — we can help amplify it and bring others.
+
+---
+
+*Know about a committee, meeting, or project we should add to this page? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -1,105 +1,108 @@
 ---
-title: "Get Involved: Westside Civic Engagement"
-description: "Committees, advisory boards, public meetings, and project comment opportunities where westside cyclists can shape better infrastructure."
+title: "Get Involved"
+description: "Committees, meetings, and projects shaping westside cycling."
 draft: true
 ---
 
-*This page is a starting draft — meeting schedules, committee names, and application windows change frequently. Please double-check every link and date before sharing.*
+*Draft. Meeting schedules and committee names change. Double-check before sharing.*
 
-Reporting a pothole gets a pothole fixed. Showing up to public meetings and joining advisory committees is how we get *better roads* — protected bike lanes, complete streets, safer crossings, and connected trail networks. The westside has more seats at the table than most people realize, and many of them sit empty.
+Reporting a pothole gets a pothole fixed. Showing up to meetings is how we get protected bike lanes, safer crossings, and connected trails. The westside has more seats at the table than people realize, and many sit empty.
 
-## Why this matters
+## High-leverage moments
 
-Most westside transportation projects are shaped years before the first orange cone shows up. By the time construction starts, the design is locked in. The high-leverage moments are:
+Projects are shaped years before the orange cones show up. By construction, the design is locked. Where to focus:
 
-- **Transportation System Plan (TSP) updates** — every 5–10 years per jurisdiction
-- **Capital Improvement Plan (CIP) hearings** — usually annual
-- **Project open houses and 30/60/90% design reviews** — project-specific
-- **Advisory committee meetings** — ongoing
-- **City council and county board meetings** — when projects come up for funding or design approval
+- Transportation System Plan (TSP) updates: every 5-10 years per jurisdiction
+- Capital Improvement Plan (CIP) hearings: usually annual
+- Project open houses and 30/60/90% design reviews
+- Advisory committee meetings
+- City council and county board meetings when projects come up for funding
 
-A handful of cyclists showing up consistently to these has an outsized effect.
+A few cyclists showing up consistently has outsized effect.
 
-## Advisory committees (recurring volunteer roles)
+## Advisory committees
 
-These are the highest-leverage commitments. Most meet monthly, are 2–3 hours, and have appointed seats — you apply, get appointed, and serve a term.
+Appointed seats, usually monthly meetings, 2-3 hours.
 
-### Washington County Bicycle Advisory Committee (WC BAC)
-Advises the county on bike infrastructure, project priorities, and policy.
-- **Meets**: monthly *(TODO: confirm cadence and location)*
-- **Apply via**: Washington County boards & commissions page *(TODO: confirm URL)*
-- **Website**: <https://www.washingtoncountyor.gov/>
+### Washington County Bicycle Advisory Committee
+Advises the county on bike infrastructure, priorities, and policy.
 
-### City Bicycle/Pedestrian Advisory Committees
-Several westside cities have or have had standing BPACs or transportation committees.
-- **City of Beaverton**: *(TODO: confirm whether a standing committee exists currently; in the past has had a Traffic Commission and project-specific committees)*
-- **City of Tigard**: *(TODO: confirm — Tigard has historically had a Transportation Advisory Committee)*
-- **City of Hillsboro**: *(TODO: confirm — Hillsboro has historically had a transportation-related committee)*
-- **City of Tualatin / Sherwood / Forest Grove**: *(TODO)*
+- Meets: monthly *(TODO: confirm)*
+- Apply via Washington County boards & commissions page *(TODO: confirm URL)*
+- Website: <https://www.washingtoncountyor.gov/>
 
-### THPRD Advisory Committees
-THPRD operates parks and most regional trails on the urban westside.
-- **Trails Advisory Committee** *(TODO: confirm current name and apply URL)*
-- **Parks & Facilities Advisory Committee** *(TODO)*
-- **Website**: <https://www.thprd.org/>
+### City committees
+*(TODO: confirm current status of each)*
+
+- Beaverton: historically a Traffic Commission and project-specific committees
+- Tigard: historically a Transportation Advisory Committee
+- Hillsboro: historically a transportation-related committee
+- Tualatin, Sherwood, Forest Grove: *(TODO)*
+
+### THPRD
+Operates parks and most regional trails on the urban westside.
+
+- Trails Advisory Committee *(TODO: confirm name and apply URL)*
+- Parks & Facilities Advisory Committee *(TODO)*
+- Website: <https://www.thprd.org/>
 
 ### Metro JPACT and TPAC
-Regional transportation policy — Joint Policy Advisory Committee on Transportation (elected officials) and Transportation Policy Alternatives Committee (staff & stakeholders). Both take public comment.
-- **Website**: <https://www.oregonmetro.gov/>
+Regional transportation policy. JPACT is elected officials, TPAC is staff and stakeholders. Both take public comment.
 
-### ODOT Region 1 Area Commission on Transportation (R1ACT)
-Advises ODOT Region 1 on state highway priorities for the Portland metro area.
-- **Website**: <https://www.oregon.gov/odot/>
+- Website: <https://www.oregonmetro.gov/>
 
-## Public meetings worth showing up to
+### ODOT Region 1 ACT
+Advises ODOT on state highway priorities for the Portland metro area.
 
-You don't need an appointed seat to attend or testify at these. Three minutes of public comment from a real cyclist with a real story is surprisingly effective.
+- Website: <https://www.oregon.gov/odot/>
 
-- **City council meetings** (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius, etc.) — usually 1–2× per month. Transportation items are typically on the consent agenda or as study sessions.
-- **Washington County Board of Commissioners** — *(TODO: confirm cadence, usually weekly Tuesdays)*
-- **THPRD Board of Directors** — *(TODO: confirm cadence, usually monthly)*
-- **Metro Council** — weekly during session
-- **Project open houses** — watch agency websites and BikePortland for announcements
+## Public meetings
+
+No appointment needed. Three minutes of public comment from a real cyclist with a real story is effective.
+
+- City council meetings (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius): 1-2x per month
+- Washington County Board of Commissioners: *(TODO: confirm)*
+- THPRD Board of Directors: *(TODO: confirm)*
+- Metro Council: weekly during session
+- Project open houses: watch agency websites and BikePortland
 
 ## Plans and projects to watch
 
-These are the documents and projects that will define westside cycling for the next decade.
+*(TODO: review yearly; this list goes stale fast.)*
 
-- **Washington County 2040 / Transportation System Plan**: *(TODO: confirm current status)*
-- **City TSP updates**: each city updates its TSP on its own cycle — check city websites
-- **Metro Regional Transportation Plan (RTP)**: updated every ~5 years
-- **TV Highway corridor improvements**: ongoing multi-jurisdictional project
-- **OR-217 improvements**: ongoing ODOT project
-- **Westside Trail completion**: gaps in the trail are being closed in phases
-- **Fanno Creek Trail completion**: gaps are being closed in phases
-- **Red Electric Trail**: planned east-west connector through Beaverton
-- **Council Creek Trail**: planned Hillsboro-to-Forest Grove rail trail
+- Washington County TSP: *(TODO: status)*
+- City TSP updates: each city on its own cycle
+- Metro Regional Transportation Plan: updated every ~5 years
+- TV Highway corridor improvements: ongoing, multi-jurisdictional
+- OR-217 improvements: ongoing ODOT project
+- Westside Trail completion: gaps being closed in phases
+- Fanno Creek Trail completion: gaps being closed in phases
+- Red Electric Trail: planned east-west connector through Beaverton
+- Council Creek Trail: planned Hillsboro-to-Forest Grove rail trail
 
-*(TODO: this list will go stale fast — review it at least once a year.)*
+## Advocacy groups
 
-## Statewide and regional advocacy groups
+These groups track meetings and produce testimony. Joining or following them multiplies your impact.
 
-You don't have to do this alone. Several groups already do the legwork of tracking meetings and producing testimony — joining or following them multiplies your impact.
+- The Street Trust: <https://thestreettrust.org/>
+- BikeLoud PDX: <https://bikeloudpdx.org/>
+- Oregon Walks: <https://oregonwalks.org/>
+- BikePortland (news and action alerts): <https://bikeportland.org/>
 
-- **The Street Trust** — <https://thestreettrust.org/>
-- **BikeLoud PDX** — <https://bikeloudpdx.org/>
-- **Oregon Walks** — <https://oregonwalks.org/>
-- **BikePortland** (news and action alerts) — <https://bikeportland.org/>
+## Giving public comment
 
-## How to give effective public comment
+- Two to three minutes is the standard limit. Practice out loud.
+- Lead with your tie to the area. "I commute by bike from Aloha to downtown Beaverton three days a week."
+- One specific story beats five general points. "Last week at Murray and Allen, I was almost right-hooked" lands harder than "we need safer streets."
+- End with a specific ask. "Please fund the protected bike lane on X in this CIP cycle."
+- Written testimony gets into the record verbatim. Email beats voicemail.
 
-- **Two to three minutes is the standard limit.** Practice it out loud.
-- **Lead with your tie to the area** — "I commute by bike from Aloha to downtown Beaverton three days a week."
-- **One specific story beats five general points.** "Last week at Murray and Allen, I was almost right-hooked because…" lands harder than "we need safer streets."
-- **End with a specific ask.** "Please fund the protected bike lane on X in this CIP cycle."
-- **Written testimony counts too** — and it gets into the record verbatim. Email beats voicemail.
+## With Ride Westside
 
-## Ways to plug in with Ride Westside
-
-- **Policy rides**: from time to time we host rides with elected officials and decision-makers. Watch the [events list](/) for upcoming ones.
-- **Open-house caravans**: when there's a project open house, we sometimes ride there together. It's more fun and it's a stronger statement to arrive on bikes.
-- **Coordinate testimony**: if you're planning to testify on a project, let us know — we can help amplify it and bring others.
+- Policy rides: occasionally we ride with elected officials. Watch the [events list](/).
+- Open-house caravans: when there's a project open house, we sometimes ride there together.
+- Coordinate testimony: if you plan to testify, let us know and we can amplify.
 
 ---
 
-*Know about a committee, meeting, or project we should add to this page? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*
+*Know about a committee, meeting, or project we should add? See the [About](/about/) section for ways to reach us.*

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -1,110 +1,99 @@
 ---
 title: "Report Infrastructure Issues"
-description: "Where to report potholes, blocked bike lanes, broken signals, missing signs, and other infrastructure problems across the westside."
+description: "Who to contact for potholes, blocked bike lanes, and broken signals across the westside."
 draft: true
 ---
 
-*This page is a starting draft — please double-check every link, phone number, and form name before publishing. Some jurisdictions periodically rename their reporting portals.*
+*Draft. Confirm every link and phone number before publishing.*
 
-Westside roads, paths, and bike lanes are maintained by a patchwork of agencies. Who owns what depends on the street, not the city you're in — a road inside Beaverton city limits might be county, state, or even Metro property. The fastest way to get something fixed is to report it to the right agency the first time.
+Westside roads are maintained by many different agencies. A road inside Beaverton might be county, state, or Metro property. Report to the right agency the first time.
 
-## Quick guide: who owns what?
+## Who owns what
 
-- **State highways** (TV Highway / OR-8, OR-217, US-26 / Sunset, OR-99W / Pacific Hwy, OR-10 / Beaverton-Hillsdale, OR-210 / Scholls Ferry): **ODOT**
-- **Major county arterials** (e.g. Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): **Washington County**
-- **City streets inside city limits**: the city (Beaverton, Tigard, Hillsboro, etc.)
-- **Regional trails** (Westside Trail, Fanno Creek Trail, Rock Creek Trail, Waterhouse Trail): usually **THPRD** or the relevant city/county; check trail signage
-- **Park paths and park access**: **THPRD** (most of the urban westside) or the city parks department
-- **Bus stops, shelters, transit signals**: **TriMet**
-- **Regional facilities** (e.g. Westside Trail bridges): may be **Metro**
+- **State highways** (TV Hwy / OR-8, OR-217, US-26, OR-99W, Beaverton-Hillsdale, Scholls Ferry): ODOT
+- **Major county arterials** (Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): Washington County
+- **City streets inside city limits**: the city
+- **Regional trails** (Westside, Fanno Creek, Rock Creek, Waterhouse): usually THPRD or the city/county; check trail signage
+- **Park paths**: THPRD or city parks
+- **Bus stops and transit signals**: TriMet
 
-If you're not sure, report it to the city or county the road runs through — they'll usually forward it.
+Not sure? Report to the city or county the road runs through. They'll forward it.
 
 ## Washington County
 
-Most arterials connecting westside cities are county-maintained, even within city limits.
+Most arterials connecting westside cities are county-maintained, even inside city limits.
 
-- **Online**: Washington County Land Use & Transportation "Report a Concern" form *(TODO: confirm current URL)*
-- **Phone (non-emergency)**: *(TODO: confirm)*
-- **Website**: <https://www.washingtoncountyor.gov/>
-- **Best for**: potholes, signal timing, signage, sweeping, vegetation overgrowth, dangerous shoulder conditions on county roads
+- Online: Land Use & Transportation "Report a Concern" *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.washingtoncountyor.gov/>
 
 ## City of Beaverton
 
-- **Online**: Beaverton Public Works service request *(TODO: confirm current URL — was "BeaverTalk"/Report-It in the past)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.beavertonoregon.gov/>
-- **Best for**: city-maintained streets, bike lane sweeping, blocked sidewalks/lanes, street trees, lighting
+- Online: Beaverton Public Works service request *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.beavertonoregon.gov/>
 
 ## City of Tigard
 
-- **Online**: Tigard "Report a Problem" / public works request *(TODO: confirm URL)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.tigard-or.gov/>
-- **Best for**: city streets in Tigard, sidewalk/lane obstructions, signage
+- Online: Tigard "Report a Problem" *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.tigard-or.gov/>
 
 ## City of Hillsboro
 
-- **Online**: City of Hillsboro service request portal *(TODO: confirm URL)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.hillsboro-oregon.gov/>
-- **Best for**: city streets in Hillsboro, downtown bike infrastructure, lighting
+- Online: Hillsboro service request portal *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.hillsboro-oregon.gov/>
 
-## Smaller westside cities
+## Smaller cities
 
-Each smaller city has its own public-works contact — usually a phone number or contact form on the city website.
-
-- **City of Tualatin**: <https://www.tualatinoregon.gov/>
-- **City of Sherwood**: <https://www.sherwoodoregon.gov/>
-- **City of Forest Grove**: <https://www.forestgrove-or.gov/>
-- **City of Cornelius**: <https://www.ci.cornelius.or.us/>
-- **City of King City**: <https://www.ci.king-city.or.us/>
-- **City of Durham**: *(TODO: confirm URL)*
-- **City of North Plains / Banks / Gaston**: *(TODO)*
+- Tualatin: <https://www.tualatinoregon.gov/>
+- Sherwood: <https://www.sherwoodoregon.gov/>
+- Forest Grove: <https://www.forestgrove-or.gov/>
+- Cornelius: <https://www.ci.cornelius.or.us/>
+- King City: <https://www.ci.king-city.or.us/>
+- Durham, North Plains, Banks, Gaston: *(TODO)*
 
 ## ODOT (state highways)
 
-Anything on TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, or Scholls Ferry is ODOT's responsibility — even inside a city.
+TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, and Scholls Ferry are ODOT, even inside a city.
 
-- **Ask ODOT**: 1-888-275-6368 (1-888-ASK-ODOT)
-- **Online**: "Report a problem on a state highway" form via TripCheck / ODOT *(TODO: confirm URL)*
-- **Website**: <https://www.oregon.gov/odot/>
-- **Best for**: anything on a state highway — debris, signal timing, signage, lane closures, construction zone issues
+- Ask ODOT: 1-888-275-6368
+- Online: ODOT / TripCheck report form *(TODO: confirm URL)*
+- Website: <https://www.oregon.gov/odot/>
 
-## THPRD (Tualatin Hills Park & Recreation District)
+## THPRD
 
-- **Online**: THPRD contact / report form *(TODO: confirm URL)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.thprd.org/>
-- **Best for**: regional trails (Westside Trail, Waterhouse, Rock Creek), park paths, trail surface issues, downed trees on trails, broken lights along paths
+- Online: THPRD contact / report form *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.thprd.org/>
+- For: regional trails, park paths, trail surface issues, downed trees, lighting
 
 ## Metro
 
-Metro owns some regional facilities and helps coordinate the regional trail network.
-
-- **Website**: <https://www.oregonmetro.gov/>
-- **Best for**: regional facility issues, regional trail-network questions, things that span multiple jurisdictions
+- Website: <https://www.oregonmetro.gov/>
+- For: regional facilities, multi-jurisdiction issues
 
 ## TriMet
 
-- **Customer service**: 503-238-RIDE (7433)
-- **Online**: <https://trimet.org/contact/>
-- **Best for**: bus stops, shelters, bus-bike rack issues, transit-signal problems, MAX-related issues
+- Customer service: 503-238-7433
+- Online: <https://trimet.org/contact/>
+- For: bus stops, shelters, bike racks, transit signals
 
-## Hazards and emergencies
+## Emergencies
 
-- **Immediate hazard to people** (e.g. live downed wire, car blocking a lane creating a crash risk, a missing manhole cover): call **911**.
-- **Crash you were part of or witnessed**: call the non-emergency line for the local police agency or 911 if anyone is hurt.
-- **Blocked bike lane** (parked car, construction sign, dumpster, etc.): report to the city or county that owns the road. If it's clearly an enforcement issue (a car parked in the lane), the local police non-emergency line is usually faster than the public-works line.
+- **Active hazard** (downed wire, car blocking a lane, missing manhole cover): 911.
+- **Crash**: 911 if anyone is hurt, otherwise the local police non-emergency line.
+- **Blocked bike lane**: report to the road owner. For a parked car, police non-emergency is usually faster than public works.
 
-## Tips for effective reports
+## Tips
 
-- **Be specific about location**: nearest cross street, mile marker, or a plus code / lat-lon dropped from your phone's map app.
-- **Include a photo** if the portal allows it. A photo with a recognizable landmark makes triage much faster.
-- **Note the direction of travel** for bike-lane issues (e.g. "eastbound bike lane on SW Farmington just east of Murray").
-- **Report the same issue twice** if nothing happens in a couple of weeks — and consider cc'ing your city councilor or county commissioner if it's a recurring problem.
-- **Follow up publicly**: tagging the agency on social media after a written report often shortens the response time.
+- Be specific. Nearest cross street, mile marker, or a dropped pin.
+- Include a photo if the portal allows it.
+- Note direction of travel for bike-lane issues.
+- Report twice if nothing happens in two weeks. Cc your councilor or commissioner for recurring problems.
+- Tagging the agency on social media after a written report often speeds things up.
 
 ---
 
-*Know of a portal we should add, or spotted a broken link? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*
+*Spotted a broken link or know of a portal we should add? See the [About](/about/) section for ways to reach us.*

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -1,0 +1,110 @@
+---
+title: "Report Infrastructure Issues"
+description: "Where to report potholes, blocked bike lanes, broken signals, missing signs, and other infrastructure problems across the westside."
+draft: true
+---
+
+*This page is a starting draft — please double-check every link, phone number, and form name before publishing. Some jurisdictions periodically rename their reporting portals.*
+
+Westside roads, paths, and bike lanes are maintained by a patchwork of agencies. Who owns what depends on the street, not the city you're in — a road inside Beaverton city limits might be county, state, or even Metro property. The fastest way to get something fixed is to report it to the right agency the first time.
+
+## Quick guide: who owns what?
+
+- **State highways** (TV Highway / OR-8, OR-217, US-26 / Sunset, OR-99W / Pacific Hwy, OR-10 / Beaverton-Hillsdale, OR-210 / Scholls Ferry): **ODOT**
+- **Major county arterials** (e.g. Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): **Washington County**
+- **City streets inside city limits**: the city (Beaverton, Tigard, Hillsboro, etc.)
+- **Regional trails** (Westside Trail, Fanno Creek Trail, Rock Creek Trail, Waterhouse Trail): usually **THPRD** or the relevant city/county; check trail signage
+- **Park paths and park access**: **THPRD** (most of the urban westside) or the city parks department
+- **Bus stops, shelters, transit signals**: **TriMet**
+- **Regional facilities** (e.g. Westside Trail bridges): may be **Metro**
+
+If you're not sure, report it to the city or county the road runs through — they'll usually forward it.
+
+## Washington County
+
+Most arterials connecting westside cities are county-maintained, even within city limits.
+
+- **Online**: Washington County Land Use & Transportation "Report a Concern" form *(TODO: confirm current URL)*
+- **Phone (non-emergency)**: *(TODO: confirm)*
+- **Website**: <https://www.washingtoncountyor.gov/>
+- **Best for**: potholes, signal timing, signage, sweeping, vegetation overgrowth, dangerous shoulder conditions on county roads
+
+## City of Beaverton
+
+- **Online**: Beaverton Public Works service request *(TODO: confirm current URL — was "BeaverTalk"/Report-It in the past)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.beavertonoregon.gov/>
+- **Best for**: city-maintained streets, bike lane sweeping, blocked sidewalks/lanes, street trees, lighting
+
+## City of Tigard
+
+- **Online**: Tigard "Report a Problem" / public works request *(TODO: confirm URL)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.tigard-or.gov/>
+- **Best for**: city streets in Tigard, sidewalk/lane obstructions, signage
+
+## City of Hillsboro
+
+- **Online**: City of Hillsboro service request portal *(TODO: confirm URL)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.hillsboro-oregon.gov/>
+- **Best for**: city streets in Hillsboro, downtown bike infrastructure, lighting
+
+## Smaller westside cities
+
+Each smaller city has its own public-works contact — usually a phone number or contact form on the city website.
+
+- **City of Tualatin**: <https://www.tualatinoregon.gov/>
+- **City of Sherwood**: <https://www.sherwoodoregon.gov/>
+- **City of Forest Grove**: <https://www.forestgrove-or.gov/>
+- **City of Cornelius**: <https://www.ci.cornelius.or.us/>
+- **City of King City**: <https://www.ci.king-city.or.us/>
+- **City of Durham**: *(TODO: confirm URL)*
+- **City of North Plains / Banks / Gaston**: *(TODO)*
+
+## ODOT (state highways)
+
+Anything on TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, or Scholls Ferry is ODOT's responsibility — even inside a city.
+
+- **Ask ODOT**: 1-888-275-6368 (1-888-ASK-ODOT)
+- **Online**: "Report a problem on a state highway" form via TripCheck / ODOT *(TODO: confirm URL)*
+- **Website**: <https://www.oregon.gov/odot/>
+- **Best for**: anything on a state highway — debris, signal timing, signage, lane closures, construction zone issues
+
+## THPRD (Tualatin Hills Park & Recreation District)
+
+- **Online**: THPRD contact / report form *(TODO: confirm URL)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.thprd.org/>
+- **Best for**: regional trails (Westside Trail, Waterhouse, Rock Creek), park paths, trail surface issues, downed trees on trails, broken lights along paths
+
+## Metro
+
+Metro owns some regional facilities and helps coordinate the regional trail network.
+
+- **Website**: <https://www.oregonmetro.gov/>
+- **Best for**: regional facility issues, regional trail-network questions, things that span multiple jurisdictions
+
+## TriMet
+
+- **Customer service**: 503-238-RIDE (7433)
+- **Online**: <https://trimet.org/contact/>
+- **Best for**: bus stops, shelters, bus-bike rack issues, transit-signal problems, MAX-related issues
+
+## Hazards and emergencies
+
+- **Immediate hazard to people** (e.g. live downed wire, car blocking a lane creating a crash risk, a missing manhole cover): call **911**.
+- **Crash you were part of or witnessed**: call the non-emergency line for the local police agency or 911 if anyone is hurt.
+- **Blocked bike lane** (parked car, construction sign, dumpster, etc.): report to the city or county that owns the road. If it's clearly an enforcement issue (a car parked in the lane), the local police non-emergency line is usually faster than the public-works line.
+
+## Tips for effective reports
+
+- **Be specific about location**: nearest cross street, mile marker, or a plus code / lat-lon dropped from your phone's map app.
+- **Include a photo** if the portal allows it. A photo with a recognizable landmark makes triage much faster.
+- **Note the direction of travel** for bike-lane issues (e.g. "eastbound bike lane on SW Farmington just east of Murray").
+- **Report the same issue twice** if nothing happens in a couple of weeks — and consider cc'ing your city councilor or county commissioner if it's a recurring problem.
+- **Follow up publicly**: tagging the agency on social media after a written report often shortens the response time.
+
+---
+
+*Know of a portal we should add, or spotted a broken link? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,12 @@
   HUGO_VERSION = "0.140.1"
   TZ = "America/Los_Angeles"
   GO_VERSION = "1.21"
+
+# Deploy previews (PRs) render drafts and future-dated content so we can
+# review work-in-progress pages before flipping `draft: false`.
+[context.deploy-preview]
+  command = "npm install && npx esbuild src/main.ts --bundle --minify --sourcemap --target=es2020 --outfile=themes/linkpage/static/js/main.js && hugo --gc --minify --buildDrafts --buildFuture --baseURL ${DEPLOY_URL:-https://ridewestside.org}/ && go run ./cmd/buildpdf"
+
+# Branch deploys (non-main branches) also render drafts.
+[context.branch-deploy]
+  command = "npm install && npx esbuild src/main.ts --bundle --minify --sourcemap --target=es2020 --outfile=themes/linkpage/static/js/main.js && hugo --gc --minify --buildDrafts --buildFuture --baseURL ${DEPLOY_URL:-https://ridewestside.org}/ && go run ./cmd/buildpdf"

--- a/themes/linkpage/layouts/_default/single.html
+++ b/themes/linkpage/layouts/_default/single.html
@@ -1,6 +1,15 @@
 {{ define "main" }}
-<article>
-    <h1>{{ .Title }}</h1>
-    {{ .Content }}
+<article class="single-page">
+    <a href="{{ "/" | relURL }}" class="back-home" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-back-home-from-{{ .File.BaseFileName }}">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+        </svg>
+        Back to Ride Westside
+    </a>
+    <h1 class="single-title">{{ .Title }}</h1>
+    {{ with .Params.description }}<p class="single-description">{{ . }}</p>{{ end }}
+    <div class="about-content single-content">
+        {{ .Content }}
+    </div>
 </article>
 {{ end }}

--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -224,6 +224,27 @@
 </section>
 {{ end }}
 
+<!-- Advocacy & Resources Section -->
+{{ $jurisdictions := .Site.GetPage "/jurisdictions" }}
+{{ $engagement := .Site.GetPage "/engagement" }}
+{{ if or $jurisdictions $engagement }}
+<section class="link-section">
+    <h2 class="section-title">Advocacy &amp; Resources</h2>
+    {{ with $jurisdictions }}
+    <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-jurisdictions">
+        <span class="link-title">Report Infrastructure Issues</span>
+        <span class="link-subtitle">Who to call for potholes, blocked bike lanes, and broken signals across the westside</span>
+    </a>
+    {{ end }}
+    {{ with $engagement }}
+    <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-engagement">
+        <span class="link-title">Get Involved</span>
+        <span class="link-subtitle">Committees, meetings, and projects shaping westside cycling</span>
+    </a>
+    {{ end }}
+</section>
+{{ end }}
+
 <!-- Press/Articles Section -->
 {{ $articles := .Site.GetPage "/articles" }}
 {{ if $articles }}

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -411,6 +411,65 @@ hr {
     color: var(--text-primary);
 }
 
+.about-content a {
+    color: var(--accent-color);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.about-content a:hover {
+    color: var(--text-primary);
+}
+
+.about-content hr {
+    border: none;
+    border-top: 1px solid var(--button-border);
+    margin: 2rem 0 1.25rem;
+}
+
+.about-content em {
+    color: var(--text-secondary);
+}
+
+/* Single Page (jurisdictions, engagement, etc.) */
+.single-page {
+    padding-top: 0.5rem;
+}
+
+.back-home {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.85rem;
+    margin-bottom: 1.5rem;
+    padding: 0.4rem 0.75rem 0.4rem 0.5rem;
+    border-radius: 999px;
+    background: var(--button-bg);
+    border: 1px solid var(--button-border);
+    transition: all 0.2s ease;
+}
+
+.back-home:hover {
+    color: var(--text-primary);
+    border-color: var(--accent-color);
+}
+
+.single-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+}
+
+.single-description {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
 /* Gallery */
 .gallery {
     display: grid;


### PR DESCRIPTION
Two new standalone draft pages for proposing to the group:
- /jurisdictions/ — where to report infrastructure issues (potholes,
  blocked bike lanes, broken signals) across Washington County cities,
  THPRD, ODOT, Metro, and TriMet.
- /engagement/ — committees, public meetings, and projects worth
  showing up to for shaping westside cycling infrastructure.

Both files are marked draft: true so they only appear in `mage serve`
previews until ready to publish. Single-page template gets a back-to-
home link and reuses the existing about-content styling. Homepage
gains an "Advocacy & Resources" section linking to both pages,
guarded by GetPage so it disappears cleanly if either page is removed.

Content is intentionally a starting draft with TODO markers wherever
a specific URL, phone number, or committee name should be confirmed
before publishing.