### PR TITLE
Add Westside Trail Community Meeting and Activism & Engagement section

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -586,7 +586,7 @@ events:
     start: "Beaverton"
     end: "Beaverton"
     start_address: "15707 SW Walker Road, Beaverton, OR 97006"
-    tags: [not-rws]
+    tags: [not-rws, advocacy]
 
   - title: "9/9 Westside Trail Draft Plan — THPRD Board Presentation"
     date: "September 9, 2026"
@@ -594,7 +594,7 @@ events:
     start: "Beaverton"
     end: "Beaverton"
     start_address: "15707 SW Walker Road, Beaverton, OR 97006"
-    tags: [not-rws]
+    tags: [not-rws, advocacy]
 
   - title: "11/11 Westside Trail Final Plan — THPRD Board Approval"
     date: "November 11, 2026"
@@ -602,7 +602,7 @@ events:
     start: "Beaverton"
     end: "Beaverton"
     start_address: "15707 SW Walker Road, Beaverton, OR 97006"
-    tags: [not-rws]
+    tags: [not-rws, advocacy]
 
   # Rides
   - title: "4/11 The Ladds 500 R2R"

--- a/content/events.md
+++ b/content/events.md
@@ -579,6 +579,15 @@ events:
     end: "Portland"
     tags: [festival, ride, not-rws, family-friendly]
 
+  # Activism & Engagement
+  - title: "6/17 Westside Trail Community Meeting"
+    date: "June 17, 2026"
+    url: "https://www.tualatinhillsparks.org/Calendar.aspx?EID=12839"
+    start: "Beaverton"
+    end: "Beaverton"
+    start_address: "15707 SW Walker Road, Beaverton, OR 97006"
+    tags: [not-rws]
+
   # Rides
   - title: "4/11 The Ladds 500 R2R"
     date: "April 11, 2026"

--- a/content/events.md
+++ b/content/events.md
@@ -588,6 +588,22 @@ events:
     start_address: "15707 SW Walker Road, Beaverton, OR 97006"
     tags: [not-rws]
 
+  - title: "9/9 Westside Trail Draft Plan — THPRD Board Presentation"
+    date: "September 9, 2026"
+    url: "https://www.thprd.org/parks-in-progress/westside-trail-bridge/"
+    start: "Beaverton"
+    end: "Beaverton"
+    start_address: "15707 SW Walker Road, Beaverton, OR 97006"
+    tags: [not-rws]
+
+  - title: "11/11 Westside Trail Final Plan — THPRD Board Approval"
+    date: "November 11, 2026"
+    url: "https://www.thprd.org/parks-in-progress/westside-trail-bridge/"
+    start: "Beaverton"
+    end: "Beaverton"
+    start_address: "15707 SW Walker Road, Beaverton, OR 97006"
+    tags: [not-rws]
+
   # Rides
   - title: "4/11 The Ladds 500 R2R"
     date: "April 11, 2026"


### PR DESCRIPTION
Adds a new section to events.md for community advocacy events, seeded
with the 6/17 Westside Trail open house at the Tualatin Hills Aquatic Center.

https://claude.ai/code/session_01XTeUd3QBYt6eCjdJfBeT9d