### PR TITLE
Add Westside Projects and Advocacy sections above events

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .vale/styles
+MinAlertLevel = warning
+
+[*.md]
+BasedOnStyles = RideWestside

--- a/.vale/styles/RideWestside/BotSpeak.yml
+++ b/.vale/styles/RideWestside/BotSpeak.yml
@@ -1,0 +1,20 @@
+extends: existence
+message: "Bot-speak: avoid '%s' — prefer more direct language."
+level: warning
+ignorecase: true
+tokens:
+  - delve
+  - seamlessly
+  - pivotal
+  - groundbreaking
+  - holistic
+  - synergy
+  - synergistic
+  - actionable
+  - impactful
+  - transformative
+  - empower
+  - supercharge
+  - game-changing
+  - cutting-edge
+  - state-of-the-art

--- a/.vale/styles/RideWestside/Hedging.yml
+++ b/.vale/styles/RideWestside/Hedging.yml
@@ -1,0 +1,14 @@
+extends: existence
+message: "Filler phrase: remove or rewrite '%s'."
+level: warning
+ignorecase: true
+tokens:
+  - "it(?:'s| is) worth noting"
+  - "it is important to note"
+  - "it should be noted"
+  - "needless to say"
+  - "in conclusion"
+  - "to summarize"
+  - "in summary"
+  - "as you can imagine"
+  - "it goes without saying"

--- a/.vale/styles/RideWestside/Substitutions.yml
+++ b/.vale/styles/RideWestside/Substitutions.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Prefer '%s' over '%s'."
+level: warning
+ignorecase: true
+swap:
+  utilize: use
+  endeavor: try
+  commence: start
+  obtain: get
+  facilitate: help

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ mage watch          # Watch TypeScript for changes (run in separate terminal)
 mage buildTS        # Compile TypeScript only
 mage clean          # Remove public/ directory
 mage checkLinks     # Validate all external links in built site
+mage checkProse     # Vale prose linting (bot-speak, hedge phrases, word substitutions)
 ```
 
 ### Event Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,10 @@ mage dev            # Alias for serve
 mage watch          # Watch TypeScript for changes (run in separate terminal)
 mage buildTS        # Compile TypeScript only
 mage clean          # Remove public/ directory
-mage checkLinks     # Validate all external links in built site
-mage checkProse     # Vale prose linting (bot-speak, hedge phrases, word substitutions)
+mage checkLinks         # Validate all external links in built site
+mage checkProse         # Vale prose linting (bot-speak, hedge phrases, word substitutions)
+mage validateContent    # Validate project page front matter (required fields, valid status)
+mage checkInternalLinks # Validate all internal links in built site resolve to real pages
 ```
 
 ### Event Management

--- a/content/about.md
+++ b/content/about.md
@@ -45,8 +45,11 @@ Whether you're a daily commuter, weekend warrior, or just bike-curious, you're w
 
 Have a question, suggestion, or want to get more involved? Send us a message.
 
-<form name="contact" method="POST" data-netlify="true" class="contact-form">
+<form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" data-netlify-recaptcha="true" class="contact-form">
   <input type="hidden" name="form-name" value="contact">
+  <p class="contact-honeypot">
+    <label>Don't fill this out if you're human: <input name="bot-field" type="text"></label>
+  </p>
   <div class="contact-field">
     <label for="contact-name">Name</label>
     <input type="text" id="contact-name" name="name" required placeholder="Your name">
@@ -59,5 +62,6 @@ Have a question, suggestion, or want to get more involved? Send us a message.
     <label for="contact-message">Message</label>
     <textarea id="contact-message" name="message" required rows="5" placeholder="What's on your mind?"></textarea>
   </div>
+  <div data-netlify-recaptcha="true"></div>
   <button type="submit" class="contact-submit">Send Message</button>
 </form>

--- a/content/about.md
+++ b/content/about.md
@@ -40,3 +40,24 @@ We believe that bikes build community. Our mission is to:
 ## Join Us
 
 Whether you're a daily commuter, weekend warrior, or just bike-curious, you're welcome to join any of our rides. No membership required, no fees, just show up and ride!
+
+## Get In Touch
+
+Have a question, suggestion, or want to get more involved? Send us a message.
+
+<form name="contact" method="POST" data-netlify="true" class="contact-form">
+  <input type="hidden" name="form-name" value="contact">
+  <div class="contact-field">
+    <label for="contact-name">Name</label>
+    <input type="text" id="contact-name" name="name" required placeholder="Your name">
+  </div>
+  <div class="contact-field">
+    <label for="contact-email">Email</label>
+    <input type="email" id="contact-email" name="email" required placeholder="you@example.com">
+  </div>
+  <div class="contact-field">
+    <label for="contact-message">Message</label>
+    <textarea id="contact-message" name="message" required rows="5" placeholder="What's on your mind?"></textarea>
+  </div>
+  <button type="submit" class="contact-submit">Send Message</button>
+</form>

--- a/content/about.md
+++ b/content/about.md
@@ -41,6 +41,10 @@ We believe that bikes build community. Our mission is to:
 
 Whether you're a daily commuter, weekend warrior, or just bike-curious, you're welcome to join any of our rides. No membership required, no fees, just show up and ride!
 
+## Website Issue
+
+If you encounter any issues with the website, please either use the contact form below or [open an issue on GitHub](https://github.com/ridewestside/website/issues).
+
 ## Get In Touch
 
 Have a question, suggestion, or want to get more involved? Send us a message.

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -1,0 +1,105 @@
+---
+title: "Get Involved: Westside Civic Engagement"
+description: "Committees, advisory boards, public meetings, and project comment opportunities where westside cyclists can shape better infrastructure."
+draft: true
+---
+
+*This page is a starting draft — meeting schedules, committee names, and application windows change frequently. Please double-check every link and date before sharing.*
+
+Reporting a pothole gets a pothole fixed. Showing up to public meetings and joining advisory committees is how we get *better roads* — protected bike lanes, complete streets, safer crossings, and connected trail networks. The westside has more seats at the table than most people realize, and many of them sit empty.
+
+## Why this matters
+
+Most westside transportation projects are shaped years before the first orange cone shows up. By the time construction starts, the design is locked in. The high-leverage moments are:
+
+- **Transportation System Plan (TSP) updates** — every 5–10 years per jurisdiction
+- **Capital Improvement Plan (CIP) hearings** — usually annual
+- **Project open houses and 30/60/90% design reviews** — project-specific
+- **Advisory committee meetings** — ongoing
+- **City council and county board meetings** — when projects come up for funding or design approval
+
+A handful of cyclists showing up consistently to these has an outsized effect.
+
+## Advisory committees (recurring volunteer roles)
+
+These are the highest-leverage commitments. Most meet monthly, are 2–3 hours, and have appointed seats — you apply, get appointed, and serve a term.
+
+### Washington County Bicycle Advisory Committee (WC BAC)
+Advises the county on bike infrastructure, project priorities, and policy.
+- **Meets**: monthly *(TODO: confirm cadence and location)*
+- **Apply via**: Washington County boards & commissions page *(TODO: confirm URL)*
+- **Website**: <https://www.washingtoncountyor.gov/>
+
+### City Bicycle/Pedestrian Advisory Committees
+Several westside cities have or have had standing BPACs or transportation committees.
+- **City of Beaverton**: *(TODO: confirm whether a standing committee exists currently; in the past has had a Traffic Commission and project-specific committees)*
+- **City of Tigard**: *(TODO: confirm — Tigard has historically had a Transportation Advisory Committee)*
+- **City of Hillsboro**: *(TODO: confirm — Hillsboro has historically had a transportation-related committee)*
+- **City of Tualatin / Sherwood / Forest Grove**: *(TODO)*
+
+### THPRD Advisory Committees
+THPRD operates parks and most regional trails on the urban westside.
+- **Trails Advisory Committee** *(TODO: confirm current name and apply URL)*
+- **Parks & Facilities Advisory Committee** *(TODO)*
+- **Website**: <https://www.thprd.org/>
+
+### Metro JPACT and TPAC
+Regional transportation policy — Joint Policy Advisory Committee on Transportation (elected officials) and Transportation Policy Alternatives Committee (staff & stakeholders). Both take public comment.
+- **Website**: <https://www.oregonmetro.gov/>
+
+### ODOT Region 1 Area Commission on Transportation (R1ACT)
+Advises ODOT Region 1 on state highway priorities for the Portland metro area.
+- **Website**: <https://www.oregon.gov/odot/>
+
+## Public meetings worth showing up to
+
+You don't need an appointed seat to attend or testify at these. Three minutes of public comment from a real cyclist with a real story is surprisingly effective.
+
+- **City council meetings** (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius, etc.) — usually 1–2× per month. Transportation items are typically on the consent agenda or as study sessions.
+- **Washington County Board of Commissioners** — *(TODO: confirm cadence, usually weekly Tuesdays)*
+- **THPRD Board of Directors** — *(TODO: confirm cadence, usually monthly)*
+- **Metro Council** — weekly during session
+- **Project open houses** — watch agency websites and BikePortland for announcements
+
+## Plans and projects to watch
+
+These are the documents and projects that will define westside cycling for the next decade.
+
+- **Washington County 2040 / Transportation System Plan**: *(TODO: confirm current status)*
+- **City TSP updates**: each city updates its TSP on its own cycle — check city websites
+- **Metro Regional Transportation Plan (RTP)**: updated every ~5 years
+- **TV Highway corridor improvements**: ongoing multi-jurisdictional project
+- **OR-217 improvements**: ongoing ODOT project
+- **Westside Trail completion**: gaps in the trail are being closed in phases
+- **Fanno Creek Trail completion**: gaps are being closed in phases
+- **Red Electric Trail**: planned east-west connector through Beaverton
+- **Council Creek Trail**: planned Hillsboro-to-Forest Grove rail trail
+
+*(TODO: this list will go stale fast — review it at least once a year.)*
+
+## Statewide and regional advocacy groups
+
+You don't have to do this alone. Several groups already do the legwork of tracking meetings and producing testimony — joining or following them multiplies your impact.
+
+- **The Street Trust** — <https://thestreettrust.org/>
+- **BikeLoud PDX** — <https://bikeloudpdx.org/>
+- **Oregon Walks** — <https://oregonwalks.org/>
+- **BikePortland** (news and action alerts) — <https://bikeportland.org/>
+
+## How to give effective public comment
+
+- **Two to three minutes is the standard limit.** Practice it out loud.
+- **Lead with your tie to the area** — "I commute by bike from Aloha to downtown Beaverton three days a week."
+- **One specific story beats five general points.** "Last week at Murray and Allen, I was almost right-hooked because…" lands harder than "we need safer streets."
+- **End with a specific ask.** "Please fund the protected bike lane on X in this CIP cycle."
+- **Written testimony counts too** — and it gets into the record verbatim. Email beats voicemail.
+
+## Ways to plug in with Ride Westside
+
+- **Policy rides**: from time to time we host rides with elected officials and decision-makers. Watch the [events list](/) for upcoming ones.
+- **Open-house caravans**: when there's a project open house, we sometimes ride there together. It's more fun and it's a stronger statement to arrive on bikes.
+- **Coordinate testimony**: if you're planning to testify on a project, let us know — we can help amplify it and bring others.
+
+---
+
+*Know about a committee, meeting, or project we should add to this page? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -139,6 +139,7 @@ See the [Westside Projects](/projects/) page for current status and resources on
 
 These groups track meetings and produce testimony. Joining or following them multiplies your impact.
 
+- **Westside Transportation Alliance (WTA)**: Washington County TDM nonprofit that advocates for bike, walk, and transit options with employers and public agencies; runs commuter incentive programs and participates in Metro and county planning forums: <https://www.wta-tma.org/>
 - **Washington County Bicycle Transportation Coalition (WashCo BTC)**: local county-focused group, tracks LUT decisions: <https://washcobtc.org/>
 - **The Street Trust**: statewide active transportation advocacy: <https://thestreettrust.org/>
 - **BikeLoud PDX**: Portland metro cycling advocacy, frequent testimony: <https://bikeloudpdx.org/>

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -144,6 +144,7 @@ These groups track meetings and produce testimony. Joining or following them mul
 - **The Street Trust**: statewide active transportation advocacy: <https://thestreettrust.org/>
 - **BikeLoud PDX**: Portland metro cycling advocacy, frequent testimony: <https://bikeloudpdx.org/>
 - **Oregon Walks**: pedestrian and walkability advocacy: <https://oregonwalks.org/>
+- **Oregon Trails Coalition**: statewide trails advocacy, funding, and policy — fiscally sponsored by Trailkeepers of Oregon; relevant for trail corridor projects like the Westside and Council Creek trails: <https://www.oregontrailscoalition.org/>
 - **BikePortland**: news, action alerts, project tracking: <https://bikeportland.org/>
 
 ## Giving public comment

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -73,12 +73,14 @@ No appointment needed. Three minutes of public comment from a real cyclist with 
 - Washington County TSP: *(TODO: status)*
 - City TSP updates: each city on its own cycle
 - Metro Regional Transportation Plan: updated every ~5 years
-- TV Highway corridor improvements: ongoing, multi-jurisdictional
+- [TV Highway corridor improvements](/projects/tv-highway/): ongoing, multi-jurisdictional
 - OR-217 improvements: ongoing ODOT project
-- Westside Trail completion: gaps being closed in phases
-- Fanno Creek Trail completion: gaps being closed in phases
-- Red Electric Trail: planned east-west connector through Beaverton
-- Council Creek Trail: planned Hillsboro-to-Forest Grove rail trail
+- [Westside Trail](/projects/westside-trail/) completion: gaps being closed in phases
+- [Fanno Creek Trail](/projects/fanno-creek-trail/) completion: gaps being closed in phases
+- [Red Electric Trail](/projects/red-electric-trail/): planned east-west connector through Beaverton
+- [Council Creek Trail](/projects/council-creek-trail/): planned Hillsboro-to-Forest Grove rail trail
+
+See the [Westside Projects](/projects/) page for current status and resources on each.
 
 ## Advocacy groups
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -6,7 +6,7 @@ draft: false
 
 Reporting a pothole gets a pothole fixed. Showing up to meetings is how we get protected bike lanes, safer crossings, and connected trails. The westside has more seats at the table than people realize, and many sit empty.
 
-## High-leverage moments
+## Showing up
 
 Projects are shaped years before the orange cones show up. By construction, the design is locked. Where to focus:
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -123,17 +123,20 @@ Watch agency websites and [BikePortland](https://bikeportland.org/) for open hou
 
 ## Plans and projects to watch
 
-- Washington County TSP: on its own update cycle; watch washingtoncountyor.gov/lut
-- City TSP updates: each city runs its own update cycle (Tigard's E-Go Strategic Transportation Plan is the current active process)
+- Washington County TSP: watch washingtoncountyor.gov/lut
+- City TSP updates: each city on its own cycle
 - Metro Regional Transportation Plan: updated every ~5 years
-- [TV Highway corridor improvements](/projects/tv-highway/): BRT locally preferred alternative selected Feb 2025; bike lane details in design
 - OR-217 improvements: ongoing ODOT project
-- [Westside Trail](/projects/westside-trail/) completion: US-26 bridge in design, construction ~2030
-- [Fanno Creek Trail](/projects/fanno-creek-trail/) completion: Scholls Ferry and Hall Blvd crossings active
-- [Red Electric Trail](/projects/red-electric-trail/): 2025 funding secured for 2-mile gap in SW Portland hills
-- [Council Creek Trail](/projects/council-creek-trail/): $19M committed, construction starting summer 2026
+- [TV Highway Corridor](/projects/tv-highway/)
+- [Westside Trail](/projects/westside-trail/)
+- [Fanno Creek Trail](/projects/fanno-creek-trail/)
+- [Red Electric Trail](/projects/red-electric-trail/)
+- [Council Creek Trail](/projects/council-creek-trail/)
+- [THPRD Westside Trail Bridge](/projects/thprd-bridge/)
+- [Hillsboro Trail Bridges](/projects/hillsboro-bridges/)
+- [Tigard Trail Crossings](/projects/tigard-bridges/)
 
-See the [Westside Projects](/projects/) page for current status and resources on each.
+See the [Westside Projects](/projects/) page for current status on each.
 
 ## Advocacy groups
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -1,10 +1,8 @@
 ---
 title: "Get Involved"
 description: "Committees, meetings, and projects shaping westside cycling."
-draft: true
+draft: false
 ---
-
-*Draft. Meeting schedules and committee names change — confirm before sharing.*
 
 Reporting a pothole gets a pothole fixed. Showing up to meetings is how we get protected bike lanes, safer crossings, and connected trails. The westside has more seats at the table than people realize, and many sit empty.
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -48,7 +48,7 @@ Acts as an advisory body to Tigard City Council on transportation matters. Eleve
 - Meets: **first Wednesday of each month, 6:00 pm**
 - Location: Tigard Public Library, 2nd floor Conference Room, 13500 SW Hall Blvd
 - Staff liaison: Sean Farrelly, 503-718-2420, sean@tigard-or.gov
-- Apply via: [Boards & Committees — City of Tigard](https://www.tigard-or.gov/Home/Components/Calendar/Event/9001/62)
+- Apply via: [Boards & Committees — City of Tigard](https://www.tigard-or.gov/Home/Components/Calendar/Event/8035/62)
 
 ### City of Hillsboro
 
@@ -65,7 +65,7 @@ THPRD operates parks and most regional trails on the urban westside. Three advis
 - **Parks & Facilities Advisory Committee** — parks capital and maintenance
 - **Equity & Engagement Advisory Committee** — programs and community access
 
-All three committees meet on the **third Wednesday of the month**. Applications open each fall (typically September). Board meetings are the **second Wednesday of each month**.
+All three committees meet on the **third Wednesday of the month**. Applications open each fall. Board meetings are the **second Wednesday of each month**.
 
 - Advisory committees: <https://www.thprd.org/district-information/advisory-committees>
 - Apply: <https://www.thprd.org/district-information/advisory-committees>
@@ -80,7 +80,7 @@ Regional transportation policy. JPACT is elected officials; TPAC is staff and st
 
 Advises ODOT on state highway priorities for the Portland metro area, including state highways in Washington County (TV Hwy, US-26, OR-217, OR-99W).
 
-- Website: <https://www.oregon.gov/odot/get-involved/pages/obpac.aspx>
+- Website: <https://www.oregon.gov/odot/get-involved/pages/act-r1.aspx>
 
 ## Public meetings
 
@@ -109,7 +109,7 @@ Meets at: Tualatin Valley Water District HQ, 1850 SW 170th Ave, Beaverton
 
 #### City of Beaverton
 
-- Meets: **first Thursday of each month, 7:00 pm**
+- Meets: **1st and 3rd Tuesday of each month, 6:00 pm**
 - Location: Beaverton Council Chambers, 12725 SW Millikan Way, Beaverton
 - Full schedule: <https://www.beavertonoregon.gov/789/City-Council>
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -111,7 +111,7 @@ Meets at: Tualatin Valley Water District HQ, 1850 SW 170th Ave, Beaverton
 
 #### City of Beaverton
 
-- Meets: **first three Tuesdays of each month**
+- Meets: **first Thursday of each month, 7:00 pm**
 - Location: Beaverton Council Chambers, 12725 SW Millikan Way, Beaverton
 - Full schedule: <https://www.beavertonoregon.gov/789/City-Council>
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -109,7 +109,32 @@ Meets at: Tualatin Valley Water District HQ, 1850 SW 170th Ave, Beaverton
 
 ### City councils
 
-Meet 1–2× per month. Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, and Cornelius all have regular sessions. Check each city's website for current schedules.
+#### City of Beaverton
+
+- Meets: **first three Tuesdays of each month**
+- Location: Beaverton Council Chambers, 12725 SW Millikan Way, Beaverton
+- Full schedule: <https://www.beavertonoregon.gov/789/City-Council>
+
+#### City of Tigard
+
+- Meets: **most Tuesdays**, business meetings at **6:30 pm** (study sessions begin earlier at 5:35 pm)
+- Location: City Hall, 13125 SW Hall Blvd, Tigard
+- Submit written comment by Monday at noon (the day before each meeting)
+- Full schedule: <https://www.tigard-or.gov/your-government/council/council-meetings>
+
+#### City of Hillsboro
+
+- Meets: **1st and 3rd Tuesdays at 7:00 pm** (work sessions at 6:00 pm)
+- Location: Hillsboro Civic Center, Conference Room 113 B&C, 150 E Main St, Hillsboro
+- Full schedule: <https://www.hillsboro-oregon.gov/our-city/city-council/council-meetings>
+
+#### City of Tualatin
+
+- Meets: **2nd and 4th Mondays at 7:00 pm** (work session begins at 5:00 pm)
+- Location: Tualatin City Services Building, 10699 SW Herman Road, Tualatin
+- Full schedule: <https://www.tualatinoregon.gov/citycouncil/council-meetings>
+
+Sherwood, Forest Grove, and Cornelius all have regular sessions as well — check each city's website for current schedules.
 
 ### Metro Council
 

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -1,105 +1,108 @@
 ---
-title: "Get Involved: Westside Civic Engagement"
-description: "Committees, advisory boards, public meetings, and project comment opportunities where westside cyclists can shape better infrastructure."
+title: "Get Involved"
+description: "Committees, meetings, and projects shaping westside cycling."
 draft: true
 ---
 
-*This page is a starting draft — meeting schedules, committee names, and application windows change frequently. Please double-check every link and date before sharing.*
+*Draft. Meeting schedules and committee names change. Double-check before sharing.*
 
-Reporting a pothole gets a pothole fixed. Showing up to public meetings and joining advisory committees is how we get *better roads* — protected bike lanes, complete streets, safer crossings, and connected trail networks. The westside has more seats at the table than most people realize, and many of them sit empty.
+Reporting a pothole gets a pothole fixed. Showing up to meetings is how we get protected bike lanes, safer crossings, and connected trails. The westside has more seats at the table than people realize, and many sit empty.
 
-## Why this matters
+## High-leverage moments
 
-Most westside transportation projects are shaped years before the first orange cone shows up. By the time construction starts, the design is locked in. The high-leverage moments are:
+Projects are shaped years before the orange cones show up. By construction, the design is locked. Where to focus:
 
-- **Transportation System Plan (TSP) updates** — every 5–10 years per jurisdiction
-- **Capital Improvement Plan (CIP) hearings** — usually annual
-- **Project open houses and 30/60/90% design reviews** — project-specific
-- **Advisory committee meetings** — ongoing
-- **City council and county board meetings** — when projects come up for funding or design approval
+- Transportation System Plan (TSP) updates: every 5-10 years per jurisdiction
+- Capital Improvement Plan (CIP) hearings: usually annual
+- Project open houses and 30/60/90% design reviews
+- Advisory committee meetings
+- City council and county board meetings when projects come up for funding
 
-A handful of cyclists showing up consistently to these has an outsized effect.
+A few cyclists showing up consistently has outsized effect.
 
-## Advisory committees (recurring volunteer roles)
+## Advisory committees
 
-These are the highest-leverage commitments. Most meet monthly, are 2–3 hours, and have appointed seats — you apply, get appointed, and serve a term.
+Appointed seats, usually monthly meetings, 2-3 hours.
 
-### Washington County Bicycle Advisory Committee (WC BAC)
-Advises the county on bike infrastructure, project priorities, and policy.
-- **Meets**: monthly *(TODO: confirm cadence and location)*
-- **Apply via**: Washington County boards & commissions page *(TODO: confirm URL)*
-- **Website**: <https://www.washingtoncountyor.gov/>
+### Washington County Bicycle Advisory Committee
+Advises the county on bike infrastructure, priorities, and policy.
 
-### City Bicycle/Pedestrian Advisory Committees
-Several westside cities have or have had standing BPACs or transportation committees.
-- **City of Beaverton**: *(TODO: confirm whether a standing committee exists currently; in the past has had a Traffic Commission and project-specific committees)*
-- **City of Tigard**: *(TODO: confirm — Tigard has historically had a Transportation Advisory Committee)*
-- **City of Hillsboro**: *(TODO: confirm — Hillsboro has historically had a transportation-related committee)*
-- **City of Tualatin / Sherwood / Forest Grove**: *(TODO)*
+- Meets: monthly *(TODO: confirm)*
+- Apply via Washington County boards & commissions page *(TODO: confirm URL)*
+- Website: <https://www.washingtoncountyor.gov/>
 
-### THPRD Advisory Committees
-THPRD operates parks and most regional trails on the urban westside.
-- **Trails Advisory Committee** *(TODO: confirm current name and apply URL)*
-- **Parks & Facilities Advisory Committee** *(TODO)*
-- **Website**: <https://www.thprd.org/>
+### City committees
+*(TODO: confirm current status of each)*
+
+- Beaverton: historically a Traffic Commission and project-specific committees
+- Tigard: historically a Transportation Advisory Committee
+- Hillsboro: historically a transportation-related committee
+- Tualatin, Sherwood, Forest Grove: *(TODO)*
+
+### THPRD
+Operates parks and most regional trails on the urban westside.
+
+- Trails Advisory Committee *(TODO: confirm name and apply URL)*
+- Parks & Facilities Advisory Committee *(TODO)*
+- Website: <https://www.thprd.org/>
 
 ### Metro JPACT and TPAC
-Regional transportation policy — Joint Policy Advisory Committee on Transportation (elected officials) and Transportation Policy Alternatives Committee (staff & stakeholders). Both take public comment.
-- **Website**: <https://www.oregonmetro.gov/>
+Regional transportation policy. JPACT is elected officials, TPAC is staff and stakeholders. Both take public comment.
 
-### ODOT Region 1 Area Commission on Transportation (R1ACT)
-Advises ODOT Region 1 on state highway priorities for the Portland metro area.
-- **Website**: <https://www.oregon.gov/odot/>
+- Website: <https://www.oregonmetro.gov/>
 
-## Public meetings worth showing up to
+### ODOT Region 1 ACT
+Advises ODOT on state highway priorities for the Portland metro area.
 
-You don't need an appointed seat to attend or testify at these. Three minutes of public comment from a real cyclist with a real story is surprisingly effective.
+- Website: <https://www.oregon.gov/odot/>
 
-- **City council meetings** (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius, etc.) — usually 1–2× per month. Transportation items are typically on the consent agenda or as study sessions.
-- **Washington County Board of Commissioners** — *(TODO: confirm cadence, usually weekly Tuesdays)*
-- **THPRD Board of Directors** — *(TODO: confirm cadence, usually monthly)*
-- **Metro Council** — weekly during session
-- **Project open houses** — watch agency websites and BikePortland for announcements
+## Public meetings
+
+No appointment needed. Three minutes of public comment from a real cyclist with a real story is effective.
+
+- City council meetings (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius): 1-2x per month
+- Washington County Board of Commissioners: *(TODO: confirm)*
+- THPRD Board of Directors: *(TODO: confirm)*
+- Metro Council: weekly during session
+- Project open houses: watch agency websites and BikePortland
 
 ## Plans and projects to watch
 
-These are the documents and projects that will define westside cycling for the next decade.
+*(TODO: review yearly; this list goes stale fast.)*
 
-- **Washington County 2040 / Transportation System Plan**: *(TODO: confirm current status)*
-- **City TSP updates**: each city updates its TSP on its own cycle — check city websites
-- **Metro Regional Transportation Plan (RTP)**: updated every ~5 years
-- **TV Highway corridor improvements**: ongoing multi-jurisdictional project
-- **OR-217 improvements**: ongoing ODOT project
-- **Westside Trail completion**: gaps in the trail are being closed in phases
-- **Fanno Creek Trail completion**: gaps are being closed in phases
-- **Red Electric Trail**: planned east-west connector through Beaverton
-- **Council Creek Trail**: planned Hillsboro-to-Forest Grove rail trail
+- Washington County TSP: *(TODO: status)*
+- City TSP updates: each city on its own cycle
+- Metro Regional Transportation Plan: updated every ~5 years
+- TV Highway corridor improvements: ongoing, multi-jurisdictional
+- OR-217 improvements: ongoing ODOT project
+- Westside Trail completion: gaps being closed in phases
+- Fanno Creek Trail completion: gaps being closed in phases
+- Red Electric Trail: planned east-west connector through Beaverton
+- Council Creek Trail: planned Hillsboro-to-Forest Grove rail trail
 
-*(TODO: this list will go stale fast — review it at least once a year.)*
+## Advocacy groups
 
-## Statewide and regional advocacy groups
+These groups track meetings and produce testimony. Joining or following them multiplies your impact.
 
-You don't have to do this alone. Several groups already do the legwork of tracking meetings and producing testimony — joining or following them multiplies your impact.
+- The Street Trust: <https://thestreettrust.org/>
+- BikeLoud PDX: <https://bikeloudpdx.org/>
+- Oregon Walks: <https://oregonwalks.org/>
+- BikePortland (news and action alerts): <https://bikeportland.org/>
 
-- **The Street Trust** — <https://thestreettrust.org/>
-- **BikeLoud PDX** — <https://bikeloudpdx.org/>
-- **Oregon Walks** — <https://oregonwalks.org/>
-- **BikePortland** (news and action alerts) — <https://bikeportland.org/>
+## Giving public comment
 
-## How to give effective public comment
+- Two to three minutes is the standard limit. Practice out loud.
+- Lead with your tie to the area. "I commute by bike from Aloha to downtown Beaverton three days a week."
+- One specific story beats five general points. "Last week at Murray and Allen, I was almost right-hooked" lands harder than "we need safer streets."
+- End with a specific ask. "Please fund the protected bike lane on X in this CIP cycle."
+- Written testimony gets into the record verbatim. Email beats voicemail.
 
-- **Two to three minutes is the standard limit.** Practice it out loud.
-- **Lead with your tie to the area** — "I commute by bike from Aloha to downtown Beaverton three days a week."
-- **One specific story beats five general points.** "Last week at Murray and Allen, I was almost right-hooked because…" lands harder than "we need safer streets."
-- **End with a specific ask.** "Please fund the protected bike lane on X in this CIP cycle."
-- **Written testimony counts too** — and it gets into the record verbatim. Email beats voicemail.
+## With Ride Westside
 
-## Ways to plug in with Ride Westside
-
-- **Policy rides**: from time to time we host rides with elected officials and decision-makers. Watch the [events list](/) for upcoming ones.
-- **Open-house caravans**: when there's a project open house, we sometimes ride there together. It's more fun and it's a stronger statement to arrive on bikes.
-- **Coordinate testimony**: if you're planning to testify on a project, let us know — we can help amplify it and bring others.
+- Policy rides: occasionally we ride with elected officials. Watch the [events list](/).
+- Open-house caravans: when there's a project open house, we sometimes ride there together.
+- Coordinate testimony: if you plan to testify, let us know and we can amplify.
 
 ---
 
-*Know about a committee, meeting, or project we should add to this page? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*
+*Know about a committee, meeting, or project we should add? See the [About](/about/) section for ways to reach us.*

--- a/content/engagement.md
+++ b/content/engagement.md
@@ -4,7 +4,7 @@ description: "Committees, meetings, and projects shaping westside cycling."
 draft: true
 ---
 
-*Draft. Meeting schedules and committee names change. Double-check before sharing.*
+*Draft. Meeting schedules and committee names change — confirm before sharing.*
 
 Reporting a pothole gets a pothole fixed. Showing up to meetings is how we get protected bike lanes, safer crossings, and connected trails. The westside has more seats at the table than people realize, and many sit empty.
 
@@ -12,7 +12,7 @@ Reporting a pothole gets a pothole fixed. Showing up to meetings is how we get p
 
 Projects are shaped years before the orange cones show up. By construction, the design is locked. Where to focus:
 
-- Transportation System Plan (TSP) updates: every 5-10 years per jurisdiction
+- Transportation System Plan (TSP) updates: every 5–10 years per jurisdiction
 - Capital Improvement Plan (CIP) hearings: usually annual
 - Project open houses and 30/60/90% design reviews
 - Advisory committee meetings
@@ -22,63 +22,116 @@ A few cyclists showing up consistently has outsized effect.
 
 ## Advisory committees
 
-Appointed seats, usually monthly meetings, 2-3 hours.
+Appointed seats, usually monthly meetings, 2–3 hours.
 
-### Washington County Bicycle Advisory Committee
-Advises the county on bike infrastructure, priorities, and policy.
+### Washington County
 
-- Meets: monthly *(TODO: confirm)*
-- Apply via Washington County boards & commissions page *(TODO: confirm URL)*
-- Website: <https://www.washingtoncountyor.gov/>
+Washington County has a **Boards & Commissions** page where transportation and land-use seats are posted when open. The county's Land Use & Transportation (LUT) department is the one to watch for bike/ped-relevant seats.
 
-### City committees
-*(TODO: confirm current status of each)*
+- Apply: [Boards and Commissions — Washington County](https://www.washingtoncountyor.gov/oao/boards-and-commissions)
+- LUT department: <https://www.washingtoncountyor.gov/lut>
 
-- Beaverton: historically a Traffic Commission and project-specific committees
-- Tigard: historically a Transportation Advisory Committee
-- Hillsboro: historically a transportation-related committee
-- Tualatin, Sherwood, Forest Grove: *(TODO)*
+The **Washington County Bicycle Transportation Coalition (WashCo BTC)** is an independent nonprofit that tracks county transportation decisions and organizes cyclists. It's worth following even if you're not on a formal committee.
+
+- Website: <https://washcobtc.org/>
+
+### City of Beaverton — Traffic Commission
+
+Advises Beaverton City Council on traffic safety, major traffic changes, and neighborhood traffic management policies. Bike and pedestrian issues come before the commission regularly.
+
+- Meets: **first Thursday of each month, 7:00 pm**
+- Location: Beaverton Building, 12725 SW Millikan Way, Beaverton
+- Apply: [Traffic Commission — Beaverton](https://www.beavertonoregon.gov/933/Traffic-Commission)
+
+### City of Tigard — Transportation Advisory Committee (TTAC)
+
+Acts as an advisory body to Tigard City Council on transportation matters. Eleven appointed members including representation from bicycle, pedestrian, and transit advocates. Three-year terms.
+
+- Meets: **first Wednesday of each month, 6:00 pm**
+- Location: Tigard Public Library, 2nd floor Conference Room, 13500 SW Hall Blvd
+- Staff liaison: Sean Farrelly, 503-718-2420, sean@tigard-or.gov
+- Apply via: [Boards & Committees — City of Tigard](https://www.tigard-or.gov/Home/Components/Calendar/Event/9001/62)
+
+### City of Hillsboro
+
+Hillsboro runs a **Bicycle & Pedestrian Capital Improvement Program** with an annual budget of roughly $1.5 million and takes public input during project development. Check the city's boards and commissions page for any current advisory seats.
+
+- Transportation: <https://www.hillsboro-oregon.gov/our-city/departments/public-works/transportation>
+- Bike/ped CIP: <https://www.hillsboro-oregon.gov/our-city/departments/parks-recreation/about-us/planning-development>
 
 ### THPRD
-Operates parks and most regional trails on the urban westside.
 
-- Trails Advisory Committee *(TODO: confirm name and apply URL)*
-- Parks & Facilities Advisory Committee *(TODO)*
-- Website: <https://www.thprd.org/>
+THPRD operates parks and most regional trails on the urban westside. Three advisory committees meet monthly and provide input on capital projects, trails, and programming. Volunteers must be 16+, live in-district, and commit to a two-year term.
+
+- **Nature & Trails Advisory Committee** — most directly relevant to trail projects
+- **Parks & Facilities Advisory Committee** — parks capital and maintenance
+- **Equity & Engagement Advisory Committee** — programs and community access
+
+All three committees meet on the **third Wednesday of the month**. Applications open each fall (typically September). Board meetings are the **second Wednesday of each month**.
+
+- Advisory committees: <https://www.thprd.org/district-information/advisory-committees>
+- Apply: <https://www.thprd.org/district-information/advisory-committees>
 
 ### Metro JPACT and TPAC
-Regional transportation policy. JPACT is elected officials, TPAC is staff and stakeholders. Both take public comment.
+
+Regional transportation policy. JPACT is elected officials; TPAC is staff and stakeholders. Both take public comment and influence how regional transportation funds are allocated.
 
 - Website: <https://www.oregonmetro.gov/>
 
-### ODOT Region 1 ACT
-Advises ODOT on state highway priorities for the Portland metro area.
+### ODOT Region 1 ACT (Area Commission on Transportation)
 
-- Website: <https://www.oregon.gov/odot/>
+Advises ODOT on state highway priorities for the Portland metro area, including state highways in Washington County (TV Hwy, US-26, OR-217, OR-99W).
+
+- Website: <https://www.oregon.gov/odot/get-involved/pages/obpac.aspx>
 
 ## Public meetings
 
-No appointment needed. Three minutes of public comment from a real cyclist with a real story is effective.
+No appointment needed. Three minutes of public comment from a real cyclist with a real story lands harder than a stack of emails.
 
-- City council meetings (Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, Cornelius): 1-2x per month
-- Washington County Board of Commissioners: *(TODO: confirm)*
-- THPRD Board of Directors: *(TODO: confirm)*
-- Metro Council: weekly during session
-- Project open houses: watch agency websites and BikePortland
+### Washington County Board of Commissioners
+
+Meets at: 155 N First Ave, Suite 300 (Auditorium), Hillsboro
+
+- **1st and 3rd Tuesday at 10:00 am**
+- **4th Tuesday at 6:30 pm**
+- Sign up to testify or submit written comment via agendas posted one week before each meeting
+- Streamed live on the County's YouTube channel
+- Full info: <https://www.washingtoncountyor.gov/bcc>
+
+### THPRD Board of Directors
+
+Meets at: Tualatin Valley Water District HQ, 1850 SW 170th Ave, Beaverton
+
+- **2nd Wednesday of each month**
+- To testify in person: pick up a testimony card at the door
+- To testify virtually: email boardofdirectors@thprd.org by noon the day of the meeting
+- Agendas and stream: <https://www.thprd.org/district-information/board-of-directors/meetings>
+
+### City councils
+
+Meet 1–2× per month. Beaverton, Tigard, Hillsboro, Tualatin, Sherwood, Forest Grove, and Cornelius all have regular sessions. Check each city's website for current schedules.
+
+### Metro Council
+
+Meets weekly during session. Agenda includes regional transportation and parks funding decisions.
+
+- <https://www.oregonmetro.gov/>
+
+### Project open houses
+
+Watch agency websites and [BikePortland](https://bikeportland.org/) for open house announcements. These are the highest-leverage moments for specific projects.
 
 ## Plans and projects to watch
 
-*(TODO: review yearly; this list goes stale fast.)*
-
-- Washington County TSP: *(TODO: status)*
-- City TSP updates: each city on its own cycle
+- Washington County TSP: on its own update cycle; watch washingtoncountyor.gov/lut
+- City TSP updates: each city runs its own update cycle (Tigard's E-Go Strategic Transportation Plan is the current active process)
 - Metro Regional Transportation Plan: updated every ~5 years
-- [TV Highway corridor improvements](/projects/tv-highway/): ongoing, multi-jurisdictional
+- [TV Highway corridor improvements](/projects/tv-highway/): BRT locally preferred alternative selected Feb 2025; bike lane details in design
 - OR-217 improvements: ongoing ODOT project
-- [Westside Trail](/projects/westside-trail/) completion: gaps being closed in phases
-- [Fanno Creek Trail](/projects/fanno-creek-trail/) completion: gaps being closed in phases
-- [Red Electric Trail](/projects/red-electric-trail/): planned east-west connector through Beaverton
-- [Council Creek Trail](/projects/council-creek-trail/): planned Hillsboro-to-Forest Grove rail trail
+- [Westside Trail](/projects/westside-trail/) completion: US-26 bridge in design, construction ~2030
+- [Fanno Creek Trail](/projects/fanno-creek-trail/) completion: Scholls Ferry and Hall Blvd crossings active
+- [Red Electric Trail](/projects/red-electric-trail/): 2025 funding secured for 2-mile gap in SW Portland hills
+- [Council Creek Trail](/projects/council-creek-trail/): $19M committed, construction starting summer 2026
 
 See the [Westside Projects](/projects/) page for current status and resources on each.
 
@@ -86,10 +139,11 @@ See the [Westside Projects](/projects/) page for current status and resources on
 
 These groups track meetings and produce testimony. Joining or following them multiplies your impact.
 
-- The Street Trust: <https://thestreettrust.org/>
-- BikeLoud PDX: <https://bikeloudpdx.org/>
-- Oregon Walks: <https://oregonwalks.org/>
-- BikePortland (news and action alerts): <https://bikeportland.org/>
+- **Washington County Bicycle Transportation Coalition (WashCo BTC)**: local county-focused group, tracks LUT decisions: <https://washcobtc.org/>
+- **The Street Trust**: statewide active transportation advocacy: <https://thestreettrust.org/>
+- **BikeLoud PDX**: Portland metro cycling advocacy, frequent testimony: <https://bikeloudpdx.org/>
+- **Oregon Walks**: pedestrian and walkability advocacy: <https://oregonwalks.org/>
+- **BikePortland**: news, action alerts, project tracking: <https://bikeportland.org/>
 
 ## Giving public comment
 
@@ -107,4 +161,4 @@ These groups track meetings and produce testimony. Joining or following them mul
 
 ---
 
-*Know about a committee, meeting, or project we should add? See the [About](/about/) section for ways to reach us.*
+*Know about a committee, meeting, or project we should add? See the [About](/) section for ways to reach us.*

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -4,95 +4,107 @@ description: "Who to contact for potholes, blocked bike lanes, and broken signal
 draft: true
 ---
 
-*Draft. Confirm every link and phone number before publishing.*
+*Draft. Confirm links and phone numbers before publishing.*
 
-Westside roads are maintained by many different agencies. A road inside Beaverton might be county, state, or Metro property. Report to the right agency the first time.
+Westside roads are maintained by many different agencies. A road inside Beaverton might be county, state, or TriMet property. Report to the right agency the first time.
 
 ## Who owns what
 
-- **State highways** (TV Hwy / OR-8, OR-217, US-26, OR-99W, Beaverton-Hillsdale, Scholls Ferry): ODOT
-- **Major county arterials** (Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): Washington County
+- **State highways** (TV Hwy / OR-8, OR-217, US-26, OR-99W, Beaverton-Hillsdale Hwy, Scholls Ferry Rd): ODOT
+- **Major county arterials** (Walker, Cornell, Murray, Farmington, Hall, Bull Mountain Rd): Washington County
 - **City streets inside city limits**: the city
-- **Regional trails** (Westside, Fanno Creek, Rock Creek, Waterhouse): usually THPRD or the city/county; check trail signage
+- **Regional trails** (Westside, Fanno Creek, Rock Creek, Waterhouse): usually THPRD or the city/county — check trail signage
 - **Park paths**: THPRD or city parks
-- **Bus stops and transit signals**: TriMet
+- **Bus stops, shelters, and transit signals**: TriMet
 
-Not sure? Report to the city or county the road runs through. They'll forward it.
+Not sure? Report to the city or county the road runs through — they'll forward it.
 
 ## Washington County
 
 Most arterials connecting westside cities are county-maintained, even inside city limits.
 
-- Online: Land Use & Transportation "Report a Concern" *(TODO: confirm URL)*
-- Phone: *(TODO)*
-- Website: <https://www.washingtoncountyor.gov/>
+- **Online:** [Road Maintenance — Washington County](https://www.washingtoncountyor.gov/lut/road-maintenance)
+- **Phone:** 503-846-ROAD (503-846-7623), Mon–Fri 8 am–5 pm
+- **Email:** lutops@washingtoncountyor.gov
+- **Website:** <https://www.washingtoncountyor.gov/lut>
 
 ## City of Beaverton
 
-- Online: Beaverton Public Works service request *(TODO: confirm URL)*
-- Phone: *(TODO)*
-- Website: <https://www.beavertonoregon.gov/>
+- **Online:** [Report a Problem — Beaverton](https://www.beavertonoregon.gov/1076/Report-a-Problem)
+- **Direct form:** [Public Works service request](https://apps2.beavertonoregon.gov/co/reportproblem/reportproblempublicworks.aspx)
+- **Website:** <https://www.beavertonoregon.gov/>
 
 ## City of Tigard
 
-- Online: Tigard "Report a Problem" *(TODO: confirm URL)*
-- Phone: *(TODO)*
-- Website: <https://www.tigard-or.gov/>
+- **Online:** [Service Request — Tigard](https://www.tigard-or.gov/community-support/service-request)
+- **Phone:** 503-718-2591, Mon–Thu 8 am–5 pm
+- **After-hours emergency** (street hazard, water, sewer): 503-639-1554
+- **Streetlight / signal issues:** [Report a signal concern — Tigard](https://www.tigard-or.gov/your-government/departments/public-works/streets/streetlight-traffic-signal-concern)
+- **Website:** <https://www.tigard-or.gov/>
 
 ## City of Hillsboro
 
-- Online: Hillsboro service request portal *(TODO: confirm URL)*
-- Phone: *(TODO)*
-- Website: <https://www.hillsboro-oregon.gov/>
+- **Online (streets and sewers):** [Report issues with streets and sewers — Hillsboro](https://www.hillsboro-oregon.gov/our-city/departments/public-works/contact-us/report-issues-with-streets-and-sewers)
+- **Online (traffic and signals):** [Report traffic and signal safety concerns — Hillsboro](https://www.hillsboro-oregon.gov/our-city/departments/public-works/contact-us/report-traffic-and-signal-issues)
+- **Phone:** 503-615-6509
+- **Website:** <https://www.hillsboro-oregon.gov/>
 
 ## Smaller cities
 
-- Tualatin: <https://www.tualatinoregon.gov/>
-- Sherwood: <https://www.sherwoodoregon.gov/>
-- Forest Grove: <https://www.forestgrove-or.gov/>
-- Cornelius: <https://www.ci.cornelius.or.us/>
-- King City: <https://www.ci.king-city.or.us/>
-- Durham, North Plains, Banks, Gaston: *(TODO)*
+- **Tualatin:** <https://www.tualatinoregon.gov/>
+- **Sherwood:** <https://www.sherwoodoregon.gov/>
+- **Forest Grove:** <https://www.forestgrove-or.gov/>
+- **Cornelius:** <https://www.ci.cornelius.or.us/>
+- **King City:** <https://www.ci.king-city.or.us/>
+- **North Plains:** <https://northplainsoregon.gov/>
+- **Durham:** <https://www.durham-or.gov/>
+- **Banks:** <https://banksoregon.gov/>
+- **Gaston:** very small city; contact Washington County LUT if unsure
 
 ## ODOT (state highways)
 
-TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, and Scholls Ferry are ODOT, even inside a city.
+TV Hwy, OR-217, US-26, OR-99W, Beaverton-Hillsdale Hwy, and Scholls Ferry Rd are ODOT facilities, even where they run through a city.
 
-- Ask ODOT: 1-888-275-6368
-- Online: ODOT / TripCheck report form *(TODO: confirm URL)*
-- Website: <https://www.oregon.gov/odot/>
+- **Phone:** 1-888-275-6368 (1-888-ASK-ODOT)
+- **Road information / 511:** dial 511 in Oregon, or 800-977-6368 outside Oregon
+- **Online:** [Contact ODOT](https://www.oregon.gov/odot/about/pages/contact-us.aspx)
+- **Website:** <https://www.oregon.gov/odot/>
 
 ## THPRD
 
-- Online: THPRD contact / report form *(TODO: confirm URL)*
-- Phone: *(TODO)*
-- Website: <https://www.thprd.org/>
-- For: regional trails, park paths, trail surface issues, downed trees, lighting
+THPRD maintains most of the regional trail network on the urban westside, including the Westside Trail, Fanno Creek Trail (Beaverton segments), Rock Creek Trail, and Waterhouse Trail.
+
+- **Online:** [Report Feedback — THPRD](https://www.thprd.org/connect/report-feedback)
+- **Phone:** 503-645-6433, Mon–Fri 8 am–5 pm
+- **Website:** <https://www.thprd.org/>
+- For: trail surface issues, downed trees, graffiti, lighting outages, trail closures
 
 ## Metro
 
-- Website: <https://www.oregonmetro.gov/>
-- For: regional facilities, multi-jurisdiction issues
+Metro owns and manages some regional natural areas and trail connections.
+
+- **Website:** <https://www.oregonmetro.gov/>
+- For: Metro-owned natural areas and regional facilities
 
 ## TriMet
 
-- Customer service: 503-238-7433
-- Online: <https://trimet.org/contact/>
-- For: bus stops, shelters, bike racks, transit signals
+- **Customer service:** 503-238-7433
+- **Online:** <https://trimet.org/contact/>
+- For: bus stops, shelters, bike racks at stops, transit signal issues
 
 ## Emergencies
 
-- **Active hazard** (downed wire, car blocking a lane, missing manhole cover): 911.
-- **Crash**: 911 if anyone is hurt, otherwise the local police non-emergency line.
-- **Blocked bike lane**: report to the road owner. For a parked car, police non-emergency is usually faster than public works.
+- **Active hazard** (downed wire, car blocking a lane, missing manhole cover): 911
+- **Crash**: 911 if anyone is hurt; local police non-emergency line otherwise
+- **Blocked bike lane by a parked car**: police non-emergency is often faster than public works
 
 ## Tips
 
-- Be specific. Nearest cross street, mile marker, or a dropped pin.
-- Include a photo if the portal allows it.
+- Be specific. Include the nearest cross street, mile marker, or drop a pin in a maps app.
+- Include a photo if the portal allows it — it speeds up triage significantly.
 - Note direction of travel for bike-lane issues.
-- Report twice if nothing happens in two weeks. Cc your councilor or commissioner for recurring problems.
-- Tagging the agency on social media after a written report often speeds things up.
+- If nothing happens in two weeks, report again and CC your city councilor or county commissioner.
+- Tagging the agency on social media after a written report often accelerates action.
 
 ## Want to go further?
 
@@ -100,4 +112,4 @@ Reporting a problem gets it fixed. Showing up to planning meetings is how the in
 
 ---
 
-*Spotted a broken link or know of a portal we should add? See the [About](/about/) section for ways to reach us.*
+*Spotted a broken link or know of a portal we should add? See the [About](/) section for ways to reach us.*

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -1,110 +1,99 @@
 ---
 title: "Report Infrastructure Issues"
-description: "Where to report potholes, blocked bike lanes, broken signals, missing signs, and other infrastructure problems across the westside."
+description: "Who to contact for potholes, blocked bike lanes, and broken signals across the westside."
 draft: true
 ---
 
-*This page is a starting draft — please double-check every link, phone number, and form name before publishing. Some jurisdictions periodically rename their reporting portals.*
+*Draft. Confirm every link and phone number before publishing.*
 
-Westside roads, paths, and bike lanes are maintained by a patchwork of agencies. Who owns what depends on the street, not the city you're in — a road inside Beaverton city limits might be county, state, or even Metro property. The fastest way to get something fixed is to report it to the right agency the first time.
+Westside roads are maintained by many different agencies. A road inside Beaverton might be county, state, or Metro property. Report to the right agency the first time.
 
-## Quick guide: who owns what?
+## Who owns what
 
-- **State highways** (TV Highway / OR-8, OR-217, US-26 / Sunset, OR-99W / Pacific Hwy, OR-10 / Beaverton-Hillsdale, OR-210 / Scholls Ferry): **ODOT**
-- **Major county arterials** (e.g. Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): **Washington County**
-- **City streets inside city limits**: the city (Beaverton, Tigard, Hillsboro, etc.)
-- **Regional trails** (Westside Trail, Fanno Creek Trail, Rock Creek Trail, Waterhouse Trail): usually **THPRD** or the relevant city/county; check trail signage
-- **Park paths and park access**: **THPRD** (most of the urban westside) or the city parks department
-- **Bus stops, shelters, transit signals**: **TriMet**
-- **Regional facilities** (e.g. Westside Trail bridges): may be **Metro**
+- **State highways** (TV Hwy / OR-8, OR-217, US-26, OR-99W, Beaverton-Hillsdale, Scholls Ferry): ODOT
+- **Major county arterials** (Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): Washington County
+- **City streets inside city limits**: the city
+- **Regional trails** (Westside, Fanno Creek, Rock Creek, Waterhouse): usually THPRD or the city/county; check trail signage
+- **Park paths**: THPRD or city parks
+- **Bus stops and transit signals**: TriMet
 
-If you're not sure, report it to the city or county the road runs through — they'll usually forward it.
+Not sure? Report to the city or county the road runs through. They'll forward it.
 
 ## Washington County
 
-Most arterials connecting westside cities are county-maintained, even within city limits.
+Most arterials connecting westside cities are county-maintained, even inside city limits.
 
-- **Online**: Washington County Land Use & Transportation "Report a Concern" form *(TODO: confirm current URL)*
-- **Phone (non-emergency)**: *(TODO: confirm)*
-- **Website**: <https://www.washingtoncountyor.gov/>
-- **Best for**: potholes, signal timing, signage, sweeping, vegetation overgrowth, dangerous shoulder conditions on county roads
+- Online: Land Use & Transportation "Report a Concern" *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.washingtoncountyor.gov/>
 
 ## City of Beaverton
 
-- **Online**: Beaverton Public Works service request *(TODO: confirm current URL — was "BeaverTalk"/Report-It in the past)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.beavertonoregon.gov/>
-- **Best for**: city-maintained streets, bike lane sweeping, blocked sidewalks/lanes, street trees, lighting
+- Online: Beaverton Public Works service request *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.beavertonoregon.gov/>
 
 ## City of Tigard
 
-- **Online**: Tigard "Report a Problem" / public works request *(TODO: confirm URL)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.tigard-or.gov/>
-- **Best for**: city streets in Tigard, sidewalk/lane obstructions, signage
+- Online: Tigard "Report a Problem" *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.tigard-or.gov/>
 
 ## City of Hillsboro
 
-- **Online**: City of Hillsboro service request portal *(TODO: confirm URL)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.hillsboro-oregon.gov/>
-- **Best for**: city streets in Hillsboro, downtown bike infrastructure, lighting
+- Online: Hillsboro service request portal *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.hillsboro-oregon.gov/>
 
-## Smaller westside cities
+## Smaller cities
 
-Each smaller city has its own public-works contact — usually a phone number or contact form on the city website.
-
-- **City of Tualatin**: <https://www.tualatinoregon.gov/>
-- **City of Sherwood**: <https://www.sherwoodoregon.gov/>
-- **City of Forest Grove**: <https://www.forestgrove-or.gov/>
-- **City of Cornelius**: <https://www.ci.cornelius.or.us/>
-- **City of King City**: <https://www.ci.king-city.or.us/>
-- **City of Durham**: *(TODO: confirm URL)*
-- **City of North Plains / Banks / Gaston**: *(TODO)*
+- Tualatin: <https://www.tualatinoregon.gov/>
+- Sherwood: <https://www.sherwoodoregon.gov/>
+- Forest Grove: <https://www.forestgrove-or.gov/>
+- Cornelius: <https://www.ci.cornelius.or.us/>
+- King City: <https://www.ci.king-city.or.us/>
+- Durham, North Plains, Banks, Gaston: *(TODO)*
 
 ## ODOT (state highways)
 
-Anything on TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, or Scholls Ferry is ODOT's responsibility — even inside a city.
+TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, and Scholls Ferry are ODOT, even inside a city.
 
-- **Ask ODOT**: 1-888-275-6368 (1-888-ASK-ODOT)
-- **Online**: "Report a problem on a state highway" form via TripCheck / ODOT *(TODO: confirm URL)*
-- **Website**: <https://www.oregon.gov/odot/>
-- **Best for**: anything on a state highway — debris, signal timing, signage, lane closures, construction zone issues
+- Ask ODOT: 1-888-275-6368
+- Online: ODOT / TripCheck report form *(TODO: confirm URL)*
+- Website: <https://www.oregon.gov/odot/>
 
-## THPRD (Tualatin Hills Park & Recreation District)
+## THPRD
 
-- **Online**: THPRD contact / report form *(TODO: confirm URL)*
-- **Phone**: *(TODO)*
-- **Website**: <https://www.thprd.org/>
-- **Best for**: regional trails (Westside Trail, Waterhouse, Rock Creek), park paths, trail surface issues, downed trees on trails, broken lights along paths
+- Online: THPRD contact / report form *(TODO: confirm URL)*
+- Phone: *(TODO)*
+- Website: <https://www.thprd.org/>
+- For: regional trails, park paths, trail surface issues, downed trees, lighting
 
 ## Metro
 
-Metro owns some regional facilities and helps coordinate the regional trail network.
-
-- **Website**: <https://www.oregonmetro.gov/>
-- **Best for**: regional facility issues, regional trail-network questions, things that span multiple jurisdictions
+- Website: <https://www.oregonmetro.gov/>
+- For: regional facilities, multi-jurisdiction issues
 
 ## TriMet
 
-- **Customer service**: 503-238-RIDE (7433)
-- **Online**: <https://trimet.org/contact/>
-- **Best for**: bus stops, shelters, bus-bike rack issues, transit-signal problems, MAX-related issues
+- Customer service: 503-238-7433
+- Online: <https://trimet.org/contact/>
+- For: bus stops, shelters, bike racks, transit signals
 
-## Hazards and emergencies
+## Emergencies
 
-- **Immediate hazard to people** (e.g. live downed wire, car blocking a lane creating a crash risk, a missing manhole cover): call **911**.
-- **Crash you were part of or witnessed**: call the non-emergency line for the local police agency or 911 if anyone is hurt.
-- **Blocked bike lane** (parked car, construction sign, dumpster, etc.): report to the city or county that owns the road. If it's clearly an enforcement issue (a car parked in the lane), the local police non-emergency line is usually faster than the public-works line.
+- **Active hazard** (downed wire, car blocking a lane, missing manhole cover): 911.
+- **Crash**: 911 if anyone is hurt, otherwise the local police non-emergency line.
+- **Blocked bike lane**: report to the road owner. For a parked car, police non-emergency is usually faster than public works.
 
-## Tips for effective reports
+## Tips
 
-- **Be specific about location**: nearest cross street, mile marker, or a plus code / lat-lon dropped from your phone's map app.
-- **Include a photo** if the portal allows it. A photo with a recognizable landmark makes triage much faster.
-- **Note the direction of travel** for bike-lane issues (e.g. "eastbound bike lane on SW Farmington just east of Murray").
-- **Report the same issue twice** if nothing happens in a couple of weeks — and consider cc'ing your city councilor or county commissioner if it's a recurring problem.
-- **Follow up publicly**: tagging the agency on social media after a written report often shortens the response time.
+- Be specific. Nearest cross street, mile marker, or a dropped pin.
+- Include a photo if the portal allows it.
+- Note direction of travel for bike-lane issues.
+- Report twice if nothing happens in two weeks. Cc your councilor or commissioner for recurring problems.
+- Tagging the agency on social media after a written report often speeds things up.
 
 ---
 
-*Know of a portal we should add, or spotted a broken link? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*
+*Spotted a broken link or know of a portal we should add? See the [About](/about/) section for ways to reach us.*

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -31,7 +31,6 @@ Most arterials connecting westside cities are county-maintained, even inside cit
 ## City of Beaverton
 
 - **Online:** [Report a Problem — Beaverton](https://www.beavertonoregon.gov/1076/Report-a-Problem)
-- **Direct form:** [Public Works service request](https://apps2.beavertonoregon.gov/co/reportproblem/reportproblempublicworks.aspx)
 - **Website:** <https://www.beavertonoregon.gov/>
 
 ## City of Tigard

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -4,7 +4,7 @@ description: "Who to contact for potholes, blocked bike lanes, and broken signal
 draft: false
 ---
 
-Westside roads are maintained by many different agencies. A road inside Beaverton might be county, state, or TriMet property. Report to the right agency the first time.
+Westside roads and trails are maintained by many different agencies. A road inside Beaverton might be county, state, or TriMet property. This is a guide on how to report issues so that they are fixed.
 
 ## Who owns what
 
@@ -51,19 +51,19 @@ Most arterials connecting westside cities are county-maintained, even inside cit
 - **Tualatin:** <https://www.tualatinoregon.gov/>
 - **Sherwood:** <https://www.sherwoodoregon.gov/>
 - **Forest Grove:** <https://www.forestgrove-or.gov/>
-- **Cornelius:** <https://www.ci.cornelius.or.us/>
+- **Cornelius:** <https://www.corneliusor.gov/>
 - **King City:** <https://www.ci.king-city.or.us/>
 - **North Plains:** <https://northplains.gov/>
 - **Durham:** <https://durham-oregon.us/>
-- **Banks:** <https://banksoregon.gov/>
-- **Gaston:** very small city; contact Washington County LUT if unsure
+- **Banks:** <https://www.cityofbanks.org/>
+- **Gaston:** <https://www.cityofgaston.com/>
 
 ## ODOT (state highways)
 
 TV Hwy, OR-217, US-26, OR-99W, Beaverton-Hillsdale Hwy, and Scholls Ferry Rd are ODOT facilities, even where they run through a city.
 
 - **Phone:** 1-888-275-6368 (1-888-ASK-ODOT)
-- **Road information / 511:** dial 511 in Oregon, or 800-977-6368 outside Oregon
+- **Road information:** dial 511 in Oregon, or 800-977-6368 outside Oregon
 - **Online:** [Contact ODOT](https://www.oregon.gov/odot/about/pages/contact-us.aspx)
 - **Website:** <https://www.oregon.gov/odot/>
 
@@ -71,7 +71,7 @@ TV Hwy, OR-217, US-26, OR-99W, Beaverton-Hillsdale Hwy, and Scholls Ferry Rd are
 
 THPRD maintains most of the regional trail network on the urban westside, including the Westside Trail, Fanno Creek Trail (Beaverton segments), Rock Creek Trail, and Waterhouse Trail.
 
-- **Online:** [Report Feedback — THPRD](https://www.thprd.org/connect/report-feedback)
+- **Online:** [Report Feedback — THPRD](https://www.tualatinhillsparks.org/535/Report-Feedback)
 - **Phone:** 503-645-6433, Mon–Fri 8 am–5 pm
 - **Website:** <https://www.thprd.org/>
 - For: trail surface issues, downed trees, graffiti, lighting outages, trail closures
@@ -93,7 +93,7 @@ Metro owns and manages some regional natural areas and trail connections.
 
 - **Active hazard** (downed wire, car blocking a lane, missing manhole cover): 911
 - **Crash**: 911 if anyone is hurt; local police non-emergency line otherwise
-- **Blocked bike lane by a parked car**: police non-emergency is often faster than public works
+- **Blocked bike lane by a parked car**: 503-629-0111 police non-emergency is often faster than public works
 
 ## Tips
 

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -1,10 +1,8 @@
 ---
 title: "Report Infrastructure Issues"
 description: "Who to contact for potholes, blocked bike lanes, and broken signals across the westside."
-draft: true
+draft: false
 ---
-
-*Draft. Confirm links and phone numbers before publishing.*
 
 Westside roads are maintained by many different agencies. A road inside Beaverton might be county, state, or TriMet property. Report to the right agency the first time.
 

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -55,8 +55,8 @@ Most arterials connecting westside cities are county-maintained, even inside cit
 - **Forest Grove:** <https://www.forestgrove-or.gov/>
 - **Cornelius:** <https://www.ci.cornelius.or.us/>
 - **King City:** <https://www.ci.king-city.or.us/>
-- **North Plains:** <https://northplainsoregon.gov/>
-- **Durham:** <https://www.durham-or.gov/>
+- **North Plains:** <https://northplains.gov/>
+- **Durham:** <https://durham-oregon.us/>
 - **Banks:** <https://banksoregon.gov/>
 - **Gaston:** very small city; contact Washington County LUT if unsure
 

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -94,6 +94,10 @@ TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, and Scholls Ferry are ODOT, even i
 - Report twice if nothing happens in two weeks. Cc your councilor or commissioner for recurring problems.
 - Tagging the agency on social media after a written report often speeds things up.
 
+## Want to go further?
+
+Reporting a problem gets it fixed. Showing up to planning meetings is how the infrastructure gets built right in the first place. See [Get Involved](/engagement/) for committees and public comment opportunities, and [Westside Projects](/projects/) for the major infrastructure efforts underway.
+
 ---
 
 *Spotted a broken link or know of a portal we should add? See the [About](/about/) section for ways to reach us.*

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -73,7 +73,7 @@ THPRD maintains most of the regional trail network on the urban westside, includ
 
 - **Online:** [Report Feedback — THPRD](https://www.tualatinhillsparks.org/535/Report-Feedback)
 - **Phone:** 503-645-6433, Mon–Fri 8 am–5 pm
-- **Website:** <https://www.thprd.org/>
+- **Website:** <https://www.tualatinhillsparks.org/>
 - For: trail surface issues, downed trees, graffiti, lighting outages, trail closures
 
 ## Metro

--- a/content/jurisdictions.md
+++ b/content/jurisdictions.md
@@ -1,0 +1,110 @@
+---
+title: "Report Infrastructure Issues"
+description: "Where to report potholes, blocked bike lanes, broken signals, missing signs, and other infrastructure problems across the westside."
+draft: true
+---
+
+*This page is a starting draft — please double-check every link, phone number, and form name before publishing. Some jurisdictions periodically rename their reporting portals.*
+
+Westside roads, paths, and bike lanes are maintained by a patchwork of agencies. Who owns what depends on the street, not the city you're in — a road inside Beaverton city limits might be county, state, or even Metro property. The fastest way to get something fixed is to report it to the right agency the first time.
+
+## Quick guide: who owns what?
+
+- **State highways** (TV Highway / OR-8, OR-217, US-26 / Sunset, OR-99W / Pacific Hwy, OR-10 / Beaverton-Hillsdale, OR-210 / Scholls Ferry): **ODOT**
+- **Major county arterials** (e.g. Walker, Cornell, Murray, Farmington, Hall, Bull Mountain): **Washington County**
+- **City streets inside city limits**: the city (Beaverton, Tigard, Hillsboro, etc.)
+- **Regional trails** (Westside Trail, Fanno Creek Trail, Rock Creek Trail, Waterhouse Trail): usually **THPRD** or the relevant city/county; check trail signage
+- **Park paths and park access**: **THPRD** (most of the urban westside) or the city parks department
+- **Bus stops, shelters, transit signals**: **TriMet**
+- **Regional facilities** (e.g. Westside Trail bridges): may be **Metro**
+
+If you're not sure, report it to the city or county the road runs through — they'll usually forward it.
+
+## Washington County
+
+Most arterials connecting westside cities are county-maintained, even within city limits.
+
+- **Online**: Washington County Land Use & Transportation "Report a Concern" form *(TODO: confirm current URL)*
+- **Phone (non-emergency)**: *(TODO: confirm)*
+- **Website**: <https://www.washingtoncountyor.gov/>
+- **Best for**: potholes, signal timing, signage, sweeping, vegetation overgrowth, dangerous shoulder conditions on county roads
+
+## City of Beaverton
+
+- **Online**: Beaverton Public Works service request *(TODO: confirm current URL — was "BeaverTalk"/Report-It in the past)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.beavertonoregon.gov/>
+- **Best for**: city-maintained streets, bike lane sweeping, blocked sidewalks/lanes, street trees, lighting
+
+## City of Tigard
+
+- **Online**: Tigard "Report a Problem" / public works request *(TODO: confirm URL)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.tigard-or.gov/>
+- **Best for**: city streets in Tigard, sidewalk/lane obstructions, signage
+
+## City of Hillsboro
+
+- **Online**: City of Hillsboro service request portal *(TODO: confirm URL)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.hillsboro-oregon.gov/>
+- **Best for**: city streets in Hillsboro, downtown bike infrastructure, lighting
+
+## Smaller westside cities
+
+Each smaller city has its own public-works contact — usually a phone number or contact form on the city website.
+
+- **City of Tualatin**: <https://www.tualatinoregon.gov/>
+- **City of Sherwood**: <https://www.sherwoodoregon.gov/>
+- **City of Forest Grove**: <https://www.forestgrove-or.gov/>
+- **City of Cornelius**: <https://www.ci.cornelius.or.us/>
+- **City of King City**: <https://www.ci.king-city.or.us/>
+- **City of Durham**: *(TODO: confirm URL)*
+- **City of North Plains / Banks / Gaston**: *(TODO)*
+
+## ODOT (state highways)
+
+Anything on TV Hwy, 217, US-26, 99W, Beaverton-Hillsdale, or Scholls Ferry is ODOT's responsibility — even inside a city.
+
+- **Ask ODOT**: 1-888-275-6368 (1-888-ASK-ODOT)
+- **Online**: "Report a problem on a state highway" form via TripCheck / ODOT *(TODO: confirm URL)*
+- **Website**: <https://www.oregon.gov/odot/>
+- **Best for**: anything on a state highway — debris, signal timing, signage, lane closures, construction zone issues
+
+## THPRD (Tualatin Hills Park & Recreation District)
+
+- **Online**: THPRD contact / report form *(TODO: confirm URL)*
+- **Phone**: *(TODO)*
+- **Website**: <https://www.thprd.org/>
+- **Best for**: regional trails (Westside Trail, Waterhouse, Rock Creek), park paths, trail surface issues, downed trees on trails, broken lights along paths
+
+## Metro
+
+Metro owns some regional facilities and helps coordinate the regional trail network.
+
+- **Website**: <https://www.oregonmetro.gov/>
+- **Best for**: regional facility issues, regional trail-network questions, things that span multiple jurisdictions
+
+## TriMet
+
+- **Customer service**: 503-238-RIDE (7433)
+- **Online**: <https://trimet.org/contact/>
+- **Best for**: bus stops, shelters, bus-bike rack issues, transit-signal problems, MAX-related issues
+
+## Hazards and emergencies
+
+- **Immediate hazard to people** (e.g. live downed wire, car blocking a lane creating a crash risk, a missing manhole cover): call **911**.
+- **Crash you were part of or witnessed**: call the non-emergency line for the local police agency or 911 if anyone is hurt.
+- **Blocked bike lane** (parked car, construction sign, dumpster, etc.): report to the city or county that owns the road. If it's clearly an enforcement issue (a car parked in the lane), the local police non-emergency line is usually faster than the public-works line.
+
+## Tips for effective reports
+
+- **Be specific about location**: nearest cross street, mile marker, or a plus code / lat-lon dropped from your phone's map app.
+- **Include a photo** if the portal allows it. A photo with a recognizable landmark makes triage much faster.
+- **Note the direction of travel** for bike-lane issues (e.g. "eastbound bike lane on SW Farmington just east of Murray").
+- **Report the same issue twice** if nothing happens in a couple of weeks — and consider cc'ing your city councilor or county commissioner if it's a recurring problem.
+- **Follow up publicly**: tagging the agency on social media after a written report often shortens the response time.
+
+---
+
+*Know of a portal we should add, or spotted a broken link? Let us know — see the [About](/about/) section on the homepage for ways to get in touch.*

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Westside Projects"
+description: "Infrastructure projects proposed, in progress, or completed on the Portland westside."
+draft: false
+---

--- a/content/projects/council-creek-trail.md
+++ b/content/projects/council-creek-trail.md
@@ -1,7 +1,7 @@
 ---
 title: "Council Creek Regional Trail"
 description: "A 15-mile planned rail-trail connecting Hillsboro, Cornelius, and Forest Grove along a former railroad corridor, with construction beginning summer 2026."
-status: "in-progress"
+status: "funded"
 agency: "Washington County / City of Hillsboro / City of Forest Grove"
 draft: false
 ---

--- a/content/projects/council-creek-trail.md
+++ b/content/projects/council-creek-trail.md
@@ -1,32 +1,46 @@
 ---
-title: "Council Creek Trail"
-description: "A planned rail-trail from Hillsboro to Forest Grove along the Council Creek corridor."
-status: "proposed"
-agency: "Washington County / City of Forest Grove"
+title: "Council Creek Regional Trail"
+description: "A 15-mile planned rail-trail connecting Hillsboro, Cornelius, and Forest Grove along a former railroad corridor, with construction beginning summer 2026."
+status: "in-progress"
+agency: "Washington County / City of Hillsboro / City of Forest Grove"
 draft: false
 ---
 
-The Council Creek Trail would convert the former Burlington Northern Santa Fe rail corridor west of Hillsboro into a shared-use path, connecting Hillsboro to Forest Grove—a distance of roughly 9 miles. It would be the only off-street trail connection across the far west side of Washington County.
+The Council Creek Regional Trail will convert a former railroad corridor into a 15-mile shared-use path connecting downtown Hillsboro, Cornelius, and Forest Grove. The corridor has been inactive since 2015. When complete, it will be the only off-street trail connection across the far western side of Washington County.
+
+## Funding
+
+Total project cost is currently estimated at **$28 million**. To date, **$19 million in committed funding** from multiple sources, including:
+
+- **$12.2 million RAISE grant** (Rebuilding American Infrastructure with Sustainability and Equity) from the U.S. Department of Transportation
+- Metro, regional, and local matching funds
+
+## Construction Timeline
+
+**Initial 6-mile segment** — Pacific University in Forest Grove to the Hatfield Government Center MAX Station in downtown Hillsboro:
+- **Construction start: summer 2026**
+- **Estimated completion: spring 2028**
+
+**North-south segment** connecting Forest Grove to Banks: design beginning spring 2026.
+
+Washington County invited public feedback on trail plans in April 2026.
 
 ## Why It Matters
 
-Hillsboro and Forest Grove are connected only by OR-8 (TV Highway) and rural roads. A protected trail along this corridor would open cycling commuting and recreation options in an area that currently has very little protected infrastructure.
-
-## Current Status
-
-The project is in early advocacy stages. The rail corridor is managed by Washington County and other entities. No funded design or construction timeline exists.
+Hillsboro to Forest Grove is currently served only by OR-8 (TV Highway) and rural roads. A protected trail along this corridor would open cycling access across the western county for commuting, school trips, and recreation — serving communities that currently have very little protected infrastructure.
 
 ## Get Involved
 
-- Washington County Land Use & Transportation is the primary agency to engage
-- Forest Grove City Council is a key partner
+- Washington County Land Use & Transportation is the lead agency
+- Forest Grove City Council is a key partner for the Forest Grove segments
+- The public comment period in April 2026 is an example of when community input matters most — watch for future engagement opportunities as design progresses
 - See [Get Involved](/engagement/) for how to participate in county transportation planning
 
 ## Resources
 
-- [Washington County Transportation](https://www.washingtoncountyor.gov/)
-- [City of Forest Grove](https://www.forestgrove-or.gov/)
-- [Oregon Rail-Trails](https://oregontrailscoalition.org/) *(confirm URL)*
+- [Council Creek Regional Trail — Washington County](https://www.washingtoncountyor.gov/lut/planning/council-creek-regional-trail)
+- [Council Creek Trail — City of Hillsboro (funding announcement)](https://www.hillsboro-oregon.gov/Home/Components/News/News/13194/4300)
+- [Washington County invites feedback — Hillsboro News Times (April 2026)](https://hillsboronewstimes.com/2026/04/30/washington-county-invites-feedback-for-council-creek-trail/)
 
 ---
 

--- a/content/projects/council-creek-trail.md
+++ b/content/projects/council-creek-trail.md
@@ -1,0 +1,33 @@
+---
+title: "Council Creek Trail"
+description: "A planned rail-trail from Hillsboro to Forest Grove along the Council Creek corridor."
+status: "proposed"
+agency: "Washington County / City of Forest Grove"
+draft: false
+---
+
+The Council Creek Trail would convert the former Burlington Northern Santa Fe rail corridor west of Hillsboro into a shared-use path, connecting Hillsboro to Forest Grove—a distance of roughly 9 miles. It would be the only off-street trail connection across the far west side of Washington County.
+
+## Why It Matters
+
+Hillsboro and Forest Grove are connected only by OR-8 (TV Highway) and rural roads. A protected trail along this corridor would open cycling commuting and recreation options in an area that currently has very little protected infrastructure.
+
+## Current Status
+
+The project is in early advocacy stages. The rail corridor is managed by Washington County and other entities. No funded design or construction timeline exists.
+
+## Get Involved
+
+- Washington County Land Use & Transportation is the primary agency to engage
+- Forest Grove City Council is a key partner
+- See [Get Involved](/engagement/) for how to participate in county transportation planning
+
+## Resources
+
+- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+- [City of Forest Grove](https://www.forestgrove-or.gov/)
+- [Oregon Rail-Trails](https://oregontrailscoalition.org/) *(confirm URL)*
+
+---
+
+*Know of an update or resource to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/council-creek-trail.md
+++ b/content/projects/council-creek-trail.md
@@ -8,14 +8,16 @@ draft: false
 
 The Council Creek Regional Trail will convert a former railroad corridor into a 15-mile shared-use path connecting downtown Hillsboro, Cornelius, and Forest Grove. The corridor has been inactive since 2015. When complete, it will be the only off-street trail connection across the far western side of Washington County.
 
-## Funding
+## Why It Matters
+
+Hillsboro to Forest Grove is currently served only by OR-8 (TV Highway) and rural roads. A protected trail along this corridor would open cycling access across the western county for commuting, school trips, and recreation — serving communities that currently have very little protected infrastructure.
+
+## Current Status
 
 Total project cost is currently estimated at **$28 million**. To date, **$19 million in committed funding** from multiple sources, including:
 
 - **$12.2 million RAISE grant** (Rebuilding American Infrastructure with Sustainability and Equity) from the U.S. Department of Transportation
 - Metro, regional, and local matching funds
-
-## Construction Timeline
 
 **Initial 6-mile segment** — Pacific University in Forest Grove to the Hatfield Government Center MAX Station in downtown Hillsboro:
 - **Construction start: summer 2026**
@@ -24,10 +26,6 @@ Total project cost is currently estimated at **$28 million**. To date, **$19 mil
 **North-south segment** connecting Forest Grove to Banks: design beginning spring 2026.
 
 Washington County invited public feedback on trail plans in April 2026.
-
-## Why It Matters
-
-Hillsboro to Forest Grove is currently served only by OR-8 (TV Highway) and rural roads. A protected trail along this corridor would open cycling access across the western county for commuting, school trips, and recreation — serving communities that currently have very little protected infrastructure.
 
 ## Get Involved
 

--- a/content/projects/fanno-creek-trail.md
+++ b/content/projects/fanno-creek-trail.md
@@ -1,7 +1,7 @@
 ---
 title: "Fanno Creek Trail"
 description: "A 15-mile multi-city greenway trail following Fanno Creek from Tualatin through Tigard and Beaverton to southwest Portland, with several segments recently completed and crossings still being improved."
-status: "in-progress"
+status: "funded"
 agency: "THPRD / City of Tigard / City of Tualatin / Portland Parks"
 draft: false
 ---

--- a/content/projects/fanno-creek-trail.md
+++ b/content/projects/fanno-creek-trail.md
@@ -8,7 +8,11 @@ draft: false
 
 The Fanno Creek Trail runs approximately 15 miles from the Tualatin River in Tualatin, north through Tigard and Beaverton, to the Willamette River in southwest Portland. It is one of the most-used multi-use trails on the westside. Multiple agencies maintain different segments; the trail vision dates to 1975.
 
-## Recent Completions
+## Why It Matters
+
+The Fanno Creek Trail is the primary off-street north-south route through the central westside. Gaps and road crossings without protection limit who can use it. A fully connected, continuous trail would link Tualatin, Tigard, and Beaverton without requiring arterial road exposure.
+
+## Current Status
 
 Tigard completed a major four-segment construction effort in late 2024 / early 2025:
 

--- a/content/projects/fanno-creek-trail.md
+++ b/content/projects/fanno-creek-trail.md
@@ -50,7 +50,7 @@ The Beaverton segment — particularly near Hall Boulevard and Scholls Ferry —
 ## Resources
 
 - [Fanno Creek Trail — City of Tigard](https://www.tigard-or.gov/your-government/departments/public-works/parks-recreation/trails/fanno-creek-trail)
-- [Fanno Creek Trail — THPRD](https://www.thprd.org/parks-and-trails/fanno-creek-trail)
+- [Fanno Creek Trail — THPRD](https://www.tualatinhillsparks.org/396/Fanno-Creek-Trail)
 - [Fanno Creek Trail Crossing at Scholls Ferry Road — Tigard](https://www.engage.tigard-or.gov/crossing)
 - [Hall Blvd / Omara St pedestrian improvements — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=23509)
 

--- a/content/projects/fanno-creek-trail.md
+++ b/content/projects/fanno-creek-trail.md
@@ -1,0 +1,34 @@
+---
+title: "Fanno Creek Trail"
+description: "A multi-city greenway trail following Fanno Creek from Portland through Beaverton, Tigard, and Tualatin."
+status: "in-progress"
+agency: "THPRD / City of Tigard / City of Tualatin"
+draft: false
+---
+
+The Fanno Creek Trail runs approximately 15 miles along Fanno Creek from its confluence with the Tualatin River in Tualatin, north through Tigard and Beaverton, to Garden Home in southwest Portland. It is one of the most-used multi-use trails on the westside, but several gaps and rough segments remain.
+
+## Current Status
+
+Established segments exist throughout the corridor, managed by a patchwork of agencies: THPRD, City of Tigard, City of Tualatin, and Portland Parks. Key gaps exist in Beaverton and near the Beaverton–Portland border.
+
+## Key Gaps
+
+- **Beaverton segment near Hall and Scholls** — trail routing crosses busy intersections without protected crossings
+- **Garden Home area** — connection to the Portland trail system is informal in places
+
+## Get Involved
+
+- Tigard has a Transportation Advisory Committee that tracks trail priorities
+- Beaverton occasionally forms project-specific advisory groups for trail improvements
+- See [Get Involved](/engagement/) for committee and public comment opportunities
+
+## Resources
+
+- [THPRD Fanno Creek Trail](https://www.thprd.org/) *(confirm current URL)*
+- [City of Tigard Parks](https://www.tigard-or.gov/)
+- [City of Tualatin Parks](https://www.tualatinoregon.gov/)
+
+---
+
+*Know of an update, gap, or resource to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/fanno-creek-trail.md
+++ b/content/projects/fanno-creek-trail.md
@@ -1,33 +1,54 @@
 ---
 title: "Fanno Creek Trail"
-description: "A multi-city greenway trail following Fanno Creek from Portland through Beaverton, Tigard, and Tualatin."
+description: "A 15-mile multi-city greenway trail following Fanno Creek from Tualatin through Tigard and Beaverton to southwest Portland, with several segments recently completed and crossings still being improved."
 status: "in-progress"
-agency: "THPRD / City of Tigard / City of Tualatin"
+agency: "THPRD / City of Tigard / City of Tualatin / Portland Parks"
 draft: false
 ---
 
-The Fanno Creek Trail runs approximately 15 miles along Fanno Creek from its confluence with the Tualatin River in Tualatin, north through Tigard and Beaverton, to Garden Home in southwest Portland. It is one of the most-used multi-use trails on the westside, but several gaps and rough segments remain.
+The Fanno Creek Trail runs approximately 15 miles from the Tualatin River in Tualatin, north through Tigard and Beaverton, to the Willamette River in southwest Portland. It is one of the most-used multi-use trails on the westside. Multiple agencies maintain different segments; the trail vision dates to 1975.
 
-## Current Status
+## Recent Completions
 
-Established segments exist throughout the corridor, managed by a patchwork of agencies: THPRD, City of Tigard, City of Tualatin, and Portland Parks. Key gaps exist in Beaverton and near the Beaverton–Portland border.
+Tigard completed a major four-segment construction effort in late 2024 / early 2025:
 
-## Key Gaps
+- **Segment 2** (Ash Ave to Hall Blvd — City Hall segment): substantially complete November 2024
+- **Segment 3** (Tigard Library to Milton Court): substantially complete January 2025, includes access to the 26-acre Fields Natural Area
+- **Segment 4** (85th Ave to Ki-A-Kuts Bridge — Durham segment): substantially complete March 2025
 
-- **Beaverton segment near Hall and Scholls** — trail routing crosses busy intersections without protected crossings
-- **Garden Home area** — connection to the Portland trail system is informal in places
+Fanno Creek Park in Tigard was also renovated in 2025, stretching from downtown Tigard's Main Street to Hall Boulevard and the Tigard Public Library.
+
+A new section near the Tiedeman Avenue area now includes a wide, sturdy pedestrian/bike bridge over Fanno Creek.
+
+## Active Crossing Improvement Projects
+
+### Scholls Ferry Road crossing
+The existing underpass at Scholls Ferry Road floods periodically, making the trail impassable. Tigard studied solutions and selected an **at-grade, mid-block pedestrian signal** located approximately 350 feet east of SW Springwood Drive. Sidewalks on either side would be widened to support two-way bike/pedestrian traffic, and the trail approach on both sides of Scholls Ferry would be reconstructed for full accessibility.
+
+### Hall Boulevard (SW Fanno Creek Trail at SW Omara Street) — *construction starting summer 2026*
+ODOT project to install **Rectangular Rapid Flashing Beacons (RRFBs)** at two locations:
+- SW Hall Boulevard at the Fanno Creek Trail
+- SW Omara Street (new RRFB with median island)
+
+Design phase runs through early 2026; construction estimated to begin summer 2026.
+
+## Remaining Gaps
+
+The Beaverton segment — particularly near Hall Boulevard and Scholls Ferry — still has stretches where the trail forces users onto roadways. The Scholls Ferry underpass flooding issue is a persistent obstacle.
 
 ## Get Involved
 
-- Tigard has a Transportation Advisory Committee that tracks trail priorities
-- Beaverton occasionally forms project-specific advisory groups for trail improvements
-- See [Get Involved](/engagement/) for committee and public comment opportunities
+- Tigard Transportation Advisory Committee and City Council for Tigard segment improvements
+- THPRD Board for segments THPRD manages
+- See [Get Involved](/engagement/) for committee listings and how to give public comment
+- See [Report Infrastructure Issues](/jurisdictions/) to report trail hazards
 
 ## Resources
 
-- [THPRD Fanno Creek Trail](https://www.thprd.org/) *(confirm current URL)*
-- [City of Tigard Parks](https://www.tigard-or.gov/)
-- [City of Tualatin Parks](https://www.tualatinoregon.gov/)
+- [Fanno Creek Trail — City of Tigard](https://www.tigard-or.gov/your-government/departments/public-works/parks-recreation/trails/fanno-creek-trail)
+- [Fanno Creek Trail — THPRD](https://www.thprd.org/parks-and-trails/fanno-creek-trail)
+- [Fanno Creek Trail Crossing at Scholls Ferry Road — Tigard](https://www.engage.tigard-or.gov/crossing)
+- [Hall Blvd / Omara St pedestrian improvements — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=23509)
 
 ---
 

--- a/content/projects/hillsboro-bridges.md
+++ b/content/projects/hillsboro-bridges.md
@@ -1,0 +1,44 @@
+---
+title: "Hillsboro Trail Bridges"
+description: "Several bridge crossings needed to complete trail gaps along creek corridors through Hillsboro."
+status: "proposed"
+agency: "City of Hillsboro / Washington County / THPRD"
+draft: false
+---
+
+Hillsboro has multiple trail corridors interrupted by creek crossings without dedicated bridge infrastructure. Completing these crossings would significantly extend the usable off-street trail network in Washington County's largest city.
+
+*(TODO: confirm the specific crossings, their status, and which agency owns each.)*
+
+## Known Gap Crossings
+
+- **Tualatin River crossing** — *(TODO: confirm location and project status)*
+- **Rock Creek crossing(s)** — Rock Creek runs through Hillsboro; several trail gaps exist near creek crossings *(TODO: confirm specific locations)*
+- **Dairy Creek crossing** — *(TODO: confirm status and agency)*
+- **Additional crossings** — *(TODO: enumerate)*
+
+## Why It Matters
+
+Hillsboro's trail network is largely built along creek greenways, but gaps at creek crossings disconnect segments that would otherwise form continuous routes. These crossings are disproportionately high-value: one bridge can unlock miles of trail on both sides.
+
+## Current Status
+
+Projects are at various stages. Some crossings may be in active design; others are unfunded long-range plan items. *(TODO: confirm status of each crossing.)*
+
+## Get Involved
+
+- Hillsboro City Council controls city transportation and parks capital budgets
+- Washington County manages some crossings on county-owned land
+- THPRD may be a partner for crossings that connect to regional trails
+- See [Get Involved](/engagement/) for how to show up effectively
+- See [Report Infrastructure Issues](/jurisdictions/) to report hazards on existing trail segments
+
+## Resources
+
+- [City of Hillsboro Transportation](https://www.hillsboro-oregon.gov/)
+- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+- [THPRD Trails](https://www.thprd.org/)
+
+---
+
+*Know the specific crossing locations or project status? See the [About](/) section for ways to reach us.*

--- a/content/projects/hillsboro-bridges.md
+++ b/content/projects/hillsboro-bridges.md
@@ -1,43 +1,45 @@
 ---
 title: "Hillsboro Trail Bridges"
-description: "Several bridge crossings needed to complete trail gaps along creek corridors through Hillsboro."
+description: "Bridge and crossing projects needed to complete trail gaps along creek corridors through Hillsboro, including the Rock Creek Trail's planned 6-mile southern extension to Rood Bridge Park."
 status: "proposed"
 agency: "City of Hillsboro / Washington County / THPRD"
 draft: false
 ---
 
-Hillsboro has multiple trail corridors interrupted by creek crossings without dedicated bridge infrastructure. Completing these crossings would significantly extend the usable off-street trail network in Washington County's largest city.
+Hillsboro's trail network runs along creek greenways, but key crossings are missing, leaving trail segments disconnected. Completing these bridges would join existing segments into continuous routes and extend access across the city.
 
-*(TODO: confirm the specific crossings, their status, and which agency owns each.)*
+## Rock Creek Trail — Southern Extension
 
-## Known Gap Crossings
+The Rock Creek Trail currently runs from north of US-26 in the Rock Creek area south to Noble Woods Park. Future plans call for extending the trail an additional **6 miles south to Rood Bridge Park**, where it would connect to the Tualatin River Water Trail. This extension requires several bridge crossings of Rock Creek along the corridor.
 
-- **Tualatin River crossing** — *(TODO: confirm location and project status)*
-- **Rock Creek crossing(s)** — Rock Creek runs through Hillsboro; several trail gaps exist near creek crossings *(TODO: confirm specific locations)*
-- **Dairy Creek crossing** — *(TODO: confirm status and agency)*
-- **Additional crossings** — *(TODO: enumerate)*
+The trail would eventually stretch from north of US-26 all the way to the Tualatin River — a continuous greenway through the heart of Hillsboro's eastern neighborhoods.
 
-## Why It Matters
+## Rood Bridge Park and the Tualatin River Connection
 
-Hillsboro's trail network is largely built along creek greenways, but gaps at creek crossings disconnect segments that would otherwise form continuous routes. These crossings are disproportionately high-value: one bridge can unlock miles of trail on both sides.
+Rood Bridge Park sits at the south end of the planned Rock Creek Trail extension, at the Tualatin River. A crossing here would tie the Rock Creek corridor into the broader regional trail network and the Tualatin River Regional Water Trail.
+
+## Other Creek Corridors
+
+Hillsboro has additional creek corridors — including Dairy Creek — where trail planning and crossing gaps exist. Specific projects and timelines for these crossings are still being developed.
 
 ## Current Status
 
-Projects are at various stages. Some crossings may be in active design; others are unfunded long-range plan items. *(TODO: confirm status of each crossing.)*
+The Rock Creek Trail extension and associated crossings are in the long-range planning stage. No funded construction timeline has been established for the southern extension segments. Hillsboro Parks & Recreation and Washington County are the primary agencies.
 
 ## Get Involved
 
-- Hillsboro City Council controls city transportation and parks capital budgets
-- Washington County manages some crossings on county-owned land
-- THPRD may be a partner for crossings that connect to regional trails
-- See [Get Involved](/engagement/) for how to show up effectively
-- See [Report Infrastructure Issues](/jurisdictions/) to report hazards on existing trail segments
+- Hillsboro City Council controls parks and transportation capital budgets
+- Washington County Land Use & Transportation manages county-owned trail corridors
+- THPRD may partner on segments connecting to regional trails
+- See [Get Involved](/engagement/) for how to participate in planning processes
+- See [Report Infrastructure Issues](/jurisdictions/) to report hazards on existing segments
 
 ## Resources
 
-- [City of Hillsboro Transportation](https://www.hillsboro-oregon.gov/)
+- [Rock Creek Trail — City of Hillsboro](https://www.hillsboro-oregon.gov/our-city/departments/parks-recreation/parks-nature/rock-creek-trail)
+- [Rood Bridge Park — City of Hillsboro](https://www.hillsboro-oregon.gov/our-city/departments/parks-recreation/parks-nature/rood-bridge-park)
+- [City of Hillsboro Parks Planning](https://www.hillsboro-oregon.gov/our-city/departments/parks-recreation/about-us/planning-development)
 - [Washington County Transportation](https://www.washingtoncountyor.gov/)
-- [THPRD Trails](https://www.thprd.org/)
 
 ---
 

--- a/content/projects/hillsboro-bridges.md
+++ b/content/projects/hillsboro-bridges.md
@@ -1,6 +1,6 @@
 ---
 title: "Hillsboro Trail Bridges"
-description: "Bridge and crossing projects needed to complete trail gaps along creek corridors through Hillsboro, including the Rock Creek Trail's planned 6-mile southern extension to Rood Bridge Park."
+description: "Bridge and crossing projects needed to complete trail gaps along creek corridors through Hillsboro, including disconnected Rock Creek Trail segments at Noble Woods and Rood Bridge Park."
 status: "proposed"
 agency: "City of Hillsboro / Washington County / THPRD"
 draft: false
@@ -18,9 +18,9 @@ The Rock Creek Trail extension and associated crossings are in the long-range pl
 
 ## Rock Creek Trail — Southern Extension
 
-The Rock Creek Trail currently runs from north of US-26 in the Rock Creek area south to Noble Woods Park. Future plans call for extending the trail an additional **6 miles south to Rood Bridge Park**, where it would connect to the Tualatin River Water Trail. This extension requires several bridge crossings of Rock Creek along the corridor.
+The Rock Creek Trail currently runs **3.1 miles** from Rock Creek Boulevard (north of US-26) south to NW Wilkins Street, with a short on-street connection continuing to a separate paved segment through Orenco Woods Nature Park. Two more sections — at Noble Woods Park and Rood Bridge Park — are planned but not yet connected to the rest of the trail. Closing those gaps requires several new bridge crossings of Rock Creek along the corridor.
 
-The trail would eventually stretch from north of US-26 all the way to the Tualatin River — a continuous greenway through the heart of Hillsboro's eastern neighborhoods.
+Once complete, the full corridor would stretch **about 8 miles** from north of US-26 to Rood Bridge Park on the Tualatin River — a continuous greenway through the heart of Hillsboro's eastern neighborhoods.
 
 ## Rood Bridge Park and the Tualatin River Connection
 

--- a/content/projects/hillsboro-bridges.md
+++ b/content/projects/hillsboro-bridges.md
@@ -8,6 +8,14 @@ draft: false
 
 Hillsboro's trail network runs along creek greenways, but key crossings are missing, leaving trail segments disconnected. Completing these bridges would join existing segments into continuous routes and extend access across the city.
 
+## Why It Matters
+
+Connected trail corridors are rare in Hillsboro. Without bridges at creek crossings, trail segments dead-end at water, pushing people back onto arterial roads. Each crossing completed multiplies the usable trail on both sides of it.
+
+## Current Status
+
+The Rock Creek Trail extension and associated crossings are in the long-range planning stage. No funded construction timeline has been established for the southern extension segments. Hillsboro Parks & Recreation and Washington County are the primary agencies.
+
 ## Rock Creek Trail — Southern Extension
 
 The Rock Creek Trail currently runs from north of US-26 in the Rock Creek area south to Noble Woods Park. Future plans call for extending the trail an additional **6 miles south to Rood Bridge Park**, where it would connect to the Tualatin River Water Trail. This extension requires several bridge crossings of Rock Creek along the corridor.
@@ -21,10 +29,6 @@ Rood Bridge Park sits at the south end of the planned Rock Creek Trail extension
 ## Other Creek Corridors
 
 Hillsboro has additional creek corridors — including Dairy Creek — where trail planning and crossing gaps exist. Specific projects and timelines for these crossings are still being developed.
-
-## Current Status
-
-The Rock Creek Trail extension and associated crossings are in the long-range planning stage. No funded construction timeline has been established for the southern extension segments. Hillsboro Parks & Recreation and Washington County are the primary agencies.
 
 ## Get Involved
 

--- a/content/projects/red-electric-trail.md
+++ b/content/projects/red-electric-trail.md
@@ -14,9 +14,9 @@ Most protected east-west trail connections on the westside are missing or incomp
 
 ## Current Status
 
-A **pedestrian and bicycle bridge** between SW Beaverton-Hillsdale Highway and SW Capitol Highway is now open, completing one of the key crossings along the corridor.
+A **pedestrian and bicycle bridge** between SW Beaverton-Hillsdale Highway and SW Capitol Highway opened in **2022**, completing one of the key crossings along the corridor.
 
-In **2025**, the Red Electric Trail received funding through the **Oregon Community Paths Program** and **Metro's Regional Flexible Funds Allocation** to close a remaining **2-mile gap** in the regional trail network through Portland's southwest hills.
+A roughly **2-mile gap** remains in the regional trail network through Portland's southwest hills. Metro and Portland Parks & Recreation have identified the corridor as a priority for future funding through programs like the Oregon Community Paths Program and Metro's Regional Flexible Funds Allocation, though full funding to close the gap has not yet been secured.
 
 The trail connects to the Fanno Creek Trail at Alpenrose Dairy on its western end and to the Willamette Greenway Trail at South Waterfront on its eastern end.
 

--- a/content/projects/red-electric-trail.md
+++ b/content/projects/red-electric-trail.md
@@ -1,0 +1,32 @@
+---
+title: "Red Electric Trail"
+description: "A planned rail-trail along the former Southern Pacific Red Electric corridor through Beaverton, creating a key east-west connector."
+status: "proposed"
+agency: "City of Beaverton / TriMet / THPRD"
+draft: false
+---
+
+The Red Electric Trail would follow the historic Southern Pacific Red Electric interurban railway corridor, creating a protected east-west trail connection through Beaverton. The corridor currently exists as a utility and rail easement—converting it to a shared-use path would fill a major gap in the westside trail network.
+
+## Why It Matters
+
+The westside lacks east-west trail connections. Most existing trails run north-south (Westside Trail, Fanno Creek Trail). The Red Electric corridor would let cyclists cross Beaverton without navigating TV Highway or Sunset Highway.
+
+## Current Status
+
+The project is in early planning and advocacy stages. No funded construction timeline has been established. Land ownership and easement rights span multiple entities, which complicates development.
+
+## Get Involved
+
+- Beaverton City Council and Transportation Commission are the key audiences
+- Include the Red Electric Trail when giving comment at any Beaverton transportation hearing
+- See [Get Involved](/engagement/) for how to show up effectively
+
+## Resources
+
+- [City of Beaverton Transportation](https://www.beavertonoregon.gov/)
+- [TriMet](https://trimet.org/) *(corridor includes TriMet right-of-way)*
+
+---
+
+*Know of an update or resource to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/red-electric-trail.md
+++ b/content/projects/red-electric-trail.md
@@ -1,7 +1,7 @@
 ---
 title: "Red Electric Trail"
 description: "A 16-mile planned rail-trail along the former Southern Pacific Red Electric interurban corridor connecting the Tualatin River to the Willamette River through Beaverton and SW Portland."
-status: "in-progress"
+status: "funded"
 agency: "Portland Parks & Recreation / City of Beaverton / TriMet / Metro"
 draft: false
 ---

--- a/content/projects/red-electric-trail.md
+++ b/content/projects/red-electric-trail.md
@@ -8,6 +8,10 @@ draft: false
 
 The Red Electric Trail follows the right-of-way of the historic Southern Pacific Red Electric interurban railway, which ran bright red passenger trains between Forest Grove, Beaverton, and downtown Portland from 1914 to 1929. When complete, the trail will run **16 miles** from the Tualatin River to the Willamette River Greenway in South Waterfront — the only regional trail making that east-west connection through the SW Portland hills.
 
+## Why It Matters
+
+Most protected east-west trail connections on the westside are missing or incomplete. The Red Electric corridor is one of the few routes that could let a cyclist travel from the Tualatin Valley to the Willamette River without using high-speed arterials. The Beaverton end of the corridor is the critical westside link.
+
 ## Current Status
 
 A **pedestrian and bicycle bridge** between SW Beaverton-Hillsdale Highway and SW Capitol Highway is now open, completing one of the key crossings along the corridor.
@@ -15,10 +19,6 @@ A **pedestrian and bicycle bridge** between SW Beaverton-Hillsdale Highway and S
 In **2025**, the Red Electric Trail received funding through the **Oregon Community Paths Program** and **Metro's Regional Flexible Funds Allocation** to close a remaining **2-mile gap** in the regional trail network through Portland's southwest hills.
 
 The trail connects to the Fanno Creek Trail at Alpenrose Dairy on its western end and to the Willamette Greenway Trail at South Waterfront on its eastern end.
-
-## Why It Matters for the Westside
-
-Most protected east-west trail connections on the westside are missing or incomplete. The Red Electric corridor is one of the few routes that could let a cyclist travel from the Tualatin Valley to the Willamette River without using high-speed arterials. The Beaverton end of the corridor is the critical westside link.
 
 ## Get Involved
 

--- a/content/projects/red-electric-trail.md
+++ b/content/projects/red-electric-trail.md
@@ -1,31 +1,38 @@
 ---
 title: "Red Electric Trail"
-description: "A planned rail-trail along the former Southern Pacific Red Electric corridor through Beaverton, creating a key east-west connector."
-status: "proposed"
-agency: "City of Beaverton / TriMet / THPRD"
+description: "A 16-mile planned rail-trail along the former Southern Pacific Red Electric interurban corridor connecting the Tualatin River to the Willamette River through Beaverton and SW Portland."
+status: "in-progress"
+agency: "Portland Parks & Recreation / City of Beaverton / TriMet / Metro"
 draft: false
 ---
 
-The Red Electric Trail would follow the historic Southern Pacific Red Electric interurban railway corridor, creating a protected east-west trail connection through Beaverton. The corridor currently exists as a utility and rail easement—converting it to a shared-use path would fill a major gap in the westside trail network.
-
-## Why It Matters
-
-The westside lacks east-west trail connections. Most existing trails run north-south (Westside Trail, Fanno Creek Trail). The Red Electric corridor would let cyclists cross Beaverton without navigating TV Highway or Sunset Highway.
+The Red Electric Trail follows the right-of-way of the historic Southern Pacific Red Electric interurban railway, which ran bright red passenger trains between Forest Grove, Beaverton, and downtown Portland from 1914 to 1929. When complete, the trail will run **16 miles** from the Tualatin River to the Willamette River Greenway in South Waterfront — the only regional trail making that east-west connection through the SW Portland hills.
 
 ## Current Status
 
-The project is in early planning and advocacy stages. No funded construction timeline has been established. Land ownership and easement rights span multiple entities, which complicates development.
+A **pedestrian and bicycle bridge** between SW Beaverton-Hillsdale Highway and SW Capitol Highway is now open, completing one of the key crossings along the corridor.
+
+In **2025**, the Red Electric Trail received funding through the **Oregon Community Paths Program** and **Metro's Regional Flexible Funds Allocation** to close a remaining **2-mile gap** in the regional trail network through Portland's southwest hills.
+
+The trail connects to the Fanno Creek Trail at Alpenrose Dairy on its western end and to the Willamette Greenway Trail at South Waterfront on its eastern end.
+
+## Why It Matters for the Westside
+
+Most protected east-west trail connections on the westside are missing or incomplete. The Red Electric corridor is one of the few routes that could let a cyclist travel from the Tualatin Valley to the Willamette River without using high-speed arterials. The Beaverton end of the corridor is the critical westside link.
 
 ## Get Involved
 
-- Beaverton City Council and Transportation Commission are the key audiences
-- Include the Red Electric Trail when giving comment at any Beaverton transportation hearing
-- See [Get Involved](/engagement/) for how to show up effectively
+- Portland Parks & Recreation leads the Portland segments; comment at Portland City Council when trail funding comes up
+- Beaverton and TriMet hold easements or right-of-way on western segments
+- Metro's Regional Trails program tracks the full corridor
+- See [Get Involved](/engagement/) for regional advocacy opportunities
 
 ## Resources
 
-- [City of Beaverton Transportation](https://www.beavertonoregon.gov/)
-- [TriMet](https://trimet.org/) *(corridor includes TriMet right-of-way)*
+- [Red Electric Trail — Portland.gov](https://www.portland.gov/parks/construction/red-electric-trail)
+- [Red Electric Bridge and Trail Project — Portland Transportation](https://www.portland.gov/transportation/pbot-projects/construction/red-electric-bridge-and-trail-project)
+- [Red Electric Trail — SWTrails PDX](https://swtrails.org/trails/red-electric/)
+- [Metro Regional Trails](https://www.oregonmetro.gov/what-metro-does/parks-and-nature-investments/regional-trails-system/major-investment-strategy)
 
 ---
 

--- a/content/projects/thprd-bridge.md
+++ b/content/projects/thprd-bridge.md
@@ -1,36 +1,48 @@
 ---
-title: "THPRD Trail Bridge"
-description: "A key bridge crossing to close a gap in the regional trail network through the Tualatin Hills."
+title: "Westside Trail Bridge over US-26"
+description: "A planned pedestrian and bicycle bridge crossing US Highway 26 to close a critical gap in the Westside Trail between SW Greenbrier Parkway and NW Cornell Road."
 status: "in-progress"
 agency: "THPRD"
 draft: false
 ---
 
-THPRD is developing a trail bridge to close a critical gap in the regional trail network through the Tualatin Hills. The crossing would connect existing trail segments that currently force cyclists and pedestrians onto arterial roads.
-
-*(TODO: confirm which specific crossing — Beaverton Creek, Reedville Creek, or other — and exact project name.)*
+THPRD is designing a dedicated pedestrian and bicycle bridge to carry the Westside Trail over US Highway 26 (Sunset Highway), closing a gap that currently forces trail users onto high-speed arterials. The crossing would connect SW Greenbrier Parkway on the south side to NW Cornell Road on the north side.
 
 ## Why It Matters
 
-Missing bridge crossings are one of the most common reasons regional trails remain incomplete. A water or road crossing without dedicated infrastructure pushes trail users onto high-speed, high-volume roads, effectively ending the trail for most people.
+US-26 is a barrier that severs the Westside Trail in the Beaverton hills. Without a bridge, cyclists and pedestrians cannot complete the full trail north-south without mixing with freeway-adjacent traffic. This crossing is one of the most important single pieces of infrastructure for the regional trail network on the westside.
 
 ## Current Status
 
-*(TODO: confirm current phase — design, environmental review, funding secured, or under construction.)*
+The project has earned over **$1.9 million in Metro 2019 Parks and Nature Bond Trail Grant** funding for design and permitting. Additional funding sources include THPRD system development charges, Metro Regional Flexible Funds, Oregon Community Paths grants, and the Washington County MSTIP Opportunity Fund.
 
-THPRD presented the broader Westside Trail completion program to Washington County and Beaverton City Council in spring 2026. This bridge project is part of that program. See the [Westside Trail](/projects/westside-trail/) page for related context.
+**Total estimated cost: $14.5–$27.2 million** depending on engineering and construction constraints (central estimate ~$18.1 million).
+
+**Community engagement** was conducted February–March 2026, with nearly 150 responses received. THPRD extended the project schedule to evaluate feedback and hold an additional in-person public meeting, anticipated spring/summer 2026.
+
+**Board milestones:**
+- Draft Trail Alignment Concept Plan → THPRD Board: September 9, 2026
+- Final plan for board approval: November 11, 2026
+- **Construction target: ~2030**, contingent on additional grant funding
+
+**Project contact:** Matt Kilmartin, 503-567-0509, m.kilmartin@thprd.org
+
+## Related THPRD Project: Beaverton Creek Trail (Segments 3 & 4)
+
+A separate but related THPRD project will build a **1.5-mile off-street trail** connecting the Westside Trail to SW Hocken Avenue through central Beaverton, running alongside the TriMet MAX corridor and Beaverton Creek. Metro approved **$2,055,647** from its 2025–2027 Regional Flexible Funds for this project. **Construction was planned to begin in 2025.** See the [Westside Trail](/projects/westside-trail/) page for full trail context.
 
 ## Get Involved
 
-- THPRD Board of Directors meetings are the primary venue for public comment on district capital projects
-- Washington County commissioners control funding for county-share contributions
-- See [Get Involved](/engagement/) for how to participate effectively
+- Attend THPRD Board of Directors meetings when the bridge project is on the agenda (September and November 2026 are key dates)
+- Submit comment during any public outreach periods
+- See [Get Involved](/engagement/) for committee opportunities and how to give effective public comment
 
 ## Resources
 
-- [THPRD Capital Projects](https://www.thprd.org/) *(confirm current URL)*
-- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+- [THPRD: Westside Trail Bridge project page](https://www.thprd.org/parks-in-progress/westside-trail-bridge/)
+- [THPRD: Beaverton Creek Trail Segments 3 & 4](https://www.thprd.org/parks-in-progress/beaverton-creek-trail/)
+- [THPRD Westside Trail](https://www.thprd.org/parks-and-trails/westside-trail)
 
 ---
 
-*Have specific project details to add? See the [About](/) section for ways to reach us.*
+*Know of an update or want to coordinate advocacy? See the [About](/) section for ways to reach us.*

--- a/content/projects/thprd-bridge.md
+++ b/content/projects/thprd-bridge.md
@@ -1,7 +1,7 @@
 ---
 title: "Westside Trail Bridge over US-26"
 description: "A planned pedestrian and bicycle bridge crossing US Highway 26 to close a critical gap in the Westside Trail between SW Greenbrier Parkway and NW Cornell Road."
-status: "in-progress"
+status: "in-design"
 agency: "THPRD"
 draft: false
 ---

--- a/content/projects/thprd-bridge.md
+++ b/content/projects/thprd-bridge.md
@@ -1,0 +1,36 @@
+---
+title: "THPRD Trail Bridge"
+description: "A key bridge crossing to close a gap in the regional trail network through the Tualatin Hills."
+status: "in-progress"
+agency: "THPRD"
+draft: false
+---
+
+THPRD is developing a trail bridge to close a critical gap in the regional trail network through the Tualatin Hills. The crossing would connect existing trail segments that currently force cyclists and pedestrians onto arterial roads.
+
+*(TODO: confirm which specific crossing — Beaverton Creek, Reedville Creek, or other — and exact project name.)*
+
+## Why It Matters
+
+Missing bridge crossings are one of the most common reasons regional trails remain incomplete. A water or road crossing without dedicated infrastructure pushes trail users onto high-speed, high-volume roads, effectively ending the trail for most people.
+
+## Current Status
+
+*(TODO: confirm current phase — design, environmental review, funding secured, or under construction.)*
+
+THPRD presented the broader Westside Trail completion program to Washington County and Beaverton City Council in spring 2026. This bridge project is part of that program. See the [Westside Trail](/projects/westside-trail/) page for related context.
+
+## Get Involved
+
+- THPRD Board of Directors meetings are the primary venue for public comment on district capital projects
+- Washington County commissioners control funding for county-share contributions
+- See [Get Involved](/engagement/) for how to participate effectively
+
+## Resources
+
+- [THPRD Capital Projects](https://www.thprd.org/) *(confirm current URL)*
+- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+
+---
+
+*Have specific project details to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/thprd-bridge.md
+++ b/content/projects/thprd-bridge.md
@@ -29,7 +29,7 @@ The project has earned over **$1.9 million in Metro 2019 Parks and Nature Bond T
 
 ## Related THPRD Project: Beaverton Creek Trail (Segments 3 & 4)
 
-A separate but related THPRD project will build a **1.5-mile off-street trail** connecting the Westside Trail to SW Hocken Avenue through central Beaverton, running alongside the TriMet MAX corridor and Beaverton Creek. Metro approved **$2,055,647** from its 2025–2027 Regional Flexible Funds for this project. **Construction was planned to begin in 2025.** See the [Westside Trail](/projects/westside-trail/) page for full trail context.
+A separate but related THPRD project will build a **1.5-mile off-street trail** connecting the Westside Trail to SW Hocken Avenue through central Beaverton, running alongside the TriMet MAX corridor and Beaverton Creek. Metro approved **$2,055,647** from its 2025–2027 Regional Flexible Funds for this project. **Construction is planned for 2025–2026.** See the [Westside Trail](/projects/westside-trail/) page for full trail context.
 
 ## Get Involved
 
@@ -39,9 +39,9 @@ A separate but related THPRD project will build a **1.5-mile off-street trail** 
 
 ## Resources
 
-- [THPRD: Westside Trail Bridge project page](https://www.thprd.org/parks-in-progress/westside-trail-bridge/)
-- [THPRD: Beaverton Creek Trail Segments 3 & 4](https://www.thprd.org/parks-in-progress/beaverton-creek-trail/)
-- [THPRD Westside Trail](https://www.thprd.org/parks-and-trails/westside-trail)
+- [THPRD: Westside Trail Bridge project page](https://www.tualatinhillsparks.org/415/Future-Westside-Trail-Bridge-over-US-Hwy)
+- [THPRD: Beaverton Creek Trail Segments 3 & 4](https://www.tualatinhillsparks.org/614/Future-Beaverton-Creek-Trail-from-Westsi)
+- [THPRD Westside Trail](https://www.tualatinhillsparks.org/314/Westside-Trail)
 
 ---
 

--- a/content/projects/tigard-bridges.md
+++ b/content/projects/tigard-bridges.md
@@ -1,0 +1,43 @@
+---
+title: "Tigard Trail Bridges"
+description: "Bridge crossings needed to complete gaps in the Fanno Creek Trail and connecting routes through Tigard."
+status: "proposed"
+agency: "City of Tigard / THPRD / Washington County"
+draft: false
+---
+
+Tigard's trail network centers on the Fanno Creek Trail, which crosses Fanno Creek multiple times as it winds through the city. Several bridge crossings are missing or in poor condition, along with gaps on connecting routes that require crossings of major roads and waterways.
+
+*(TODO: confirm the specific crossings, their status, and which agency owns each.)*
+
+## Known Gap Crossings
+
+- **Fanno Creek Trail crossings** — the trail crosses Fanno Creek repeatedly; some crossings have gaps or require on-road detours *(TODO: enumerate specific locations)*
+- **OR-99W crossing** — a protected pedestrian/bike crossing of Pacific Highway is a long-discussed need in Tigard *(TODO: confirm project status and agency lead)*
+- **Summer Creek crossing(s)** — *(TODO: confirm location and status)*
+- **Additional crossings** — *(TODO: enumerate)*
+
+## Why It Matters
+
+The Fanno Creek Trail is one of the most-used multi-use paths in the region, but gaps and road crossings without protection make the full corridor inaccessible to many riders and pedestrians. A complete, connected trail would serve Tigard's downtown, transit center, and residential areas without requiring arterial road use.
+
+## Current Status
+
+Projects are at various stages. Tigard's Transportation System Plan identifies several crossing improvements as priorities. *(TODO: confirm which crossings are funded, designed, or under construction.)*
+
+## Get Involved
+
+- Tigard City Council and its Transportation Advisory Committee are the primary bodies for trail and crossing investments
+- THPRD manages some segments and may be a partner on crossings near regional trails
+- See [Get Involved](/engagement/) for how to participate in planning processes
+- See [Report Infrastructure Issues](/jurisdictions/) to report hazards on existing segments
+
+## Resources
+
+- [City of Tigard Transportation](https://www.tigard-or.gov/)
+- [THPRD Fanno Creek Trail](https://www.thprd.org/)
+- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+
+---
+
+*Know the specific crossing locations or project status? See the [About](/) section for ways to reach us.*

--- a/content/projects/tigard-bridges.md
+++ b/content/projects/tigard-bridges.md
@@ -37,7 +37,7 @@ ODOT is installing a **Rectangular Rapid Flashing Beacon (RRFB)** at the Fanno C
 
 ### OR-99W / Downtown Tigard
 
-The Fanno Creek Trail already passes under OR-99W via an underpass near downtown Tigard. A mural of native wildlife (by artist Jeremy Nichols) was added to the passage in 2025, and the passage is LED-lit. No additional crossing infrastructure is currently in the active project pipeline here, but connectivity from the trail to Main Street and the Tigard Transit Center remains a priority.
+The Fanno Creek Trail already passes under OR-99W via an underpass near downtown Tigard. A mural of native wildlife (by artist Jeremy Nichols) was added to the passage in 2019, and the passage is LED-lit. No additional crossing infrastructure is currently in the active project pipeline here, but connectivity from the trail to Main Street and the Tigard Transit Center remains a priority.
 
 ## Recent Trail Completions (context)
 
@@ -60,7 +60,7 @@ See the [Fanno Creek Trail](/projects/fanno-creek-trail/) page for the full pict
 - [Fanno Creek Trail — City of Tigard](https://www.tigard-or.gov/your-government/departments/public-works/parks-recreation/trails/fanno-creek-trail)
 - [Fanno Creek Trail Crossing at Scholls Ferry Road](https://www.engage.tigard-or.gov/crossing)
 - [Hall Blvd / Omara St pedestrian improvements — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=23509)
-- [Fanno Creek Trail — THPRD](https://www.thprd.org/parks-and-trails/fanno-creek-trail)
+- [Fanno Creek Trail — THPRD](https://www.tualatinhillsparks.org/396/Fanno-Creek-Trail)
 
 ---
 

--- a/content/projects/tigard-bridges.md
+++ b/content/projects/tigard-bridges.md
@@ -1,43 +1,57 @@
 ---
-title: "Tigard Trail Bridges"
-description: "Bridge crossings needed to complete gaps in the Fanno Creek Trail and connecting routes through Tigard."
-status: "proposed"
-agency: "City of Tigard / THPRD / Washington County"
+title: "Tigard Trail Crossings"
+description: "Road crossing improvements on the Fanno Creek Trail through Tigard, including the Scholls Ferry Road grade crossing and Hall Boulevard RRFB beacons."
+status: "in-progress"
+agency: "City of Tigard / ODOT / THPRD"
 draft: false
 ---
 
-Tigard's trail network centers on the Fanno Creek Trail, which crosses Fanno Creek multiple times as it winds through the city. Several bridge crossings are missing or in poor condition, along with gaps on connecting routes that require crossings of major roads and waterways.
+Tigard has multiple active projects improving trail crossings of arterial roads on the Fanno Creek Trail corridor. The trail itself recently saw major construction completed in 2024–2025; the remaining work focuses on making road crossings safer and more accessible.
 
-*(TODO: confirm the specific crossings, their status, and which agency owns each.)*
+## Scholls Ferry Road — At-Grade Crossing
 
-## Known Gap Crossings
+**The problem:** The existing Fanno Creek Trail underpass at Scholls Ferry Road floods periodically, forcing trail users onto the street without protection.
 
-- **Fanno Creek Trail crossings** — the trail crosses Fanno Creek repeatedly; some crossings have gaps or require on-road detours *(TODO: enumerate specific locations)*
-- **OR-99W crossing** — a protected pedestrian/bike crossing of Pacific Highway is a long-discussed need in Tigard *(TODO: confirm project status and agency lead)*
-- **Summer Creek crossing(s)** — *(TODO: confirm location and status)*
-- **Additional crossings** — *(TODO: enumerate)*
+**The solution:** After a community engagement process, Tigard selected an **at-grade, mid-block pedestrian signal** located approximately **350 feet east of SW Springwood Drive**. Key features:
+- Pedestrian-activated signal at street level (safer and flood-free vs. the underpass)
+- Sidewalks on both sides of Scholls Ferry widened to support two-way bike/pedestrian traffic
+- Trail approaches on both sides of the road reconstructed for full ADA accessibility
 
-## Why It Matters
+## Hall Boulevard at Fanno Creek Trail — *construction summer 2026*
 
-The Fanno Creek Trail is one of the most-used multi-use paths in the region, but gaps and road crossings without protection make the full corridor inaccessible to many riders and pedestrians. A complete, connected trail would serve Tigard's downtown, transit center, and residential areas without requiring arterial road use.
+ODOT is installing a **Rectangular Rapid Flashing Beacon (RRFB)** at the Fanno Creek Trail crossing of SW Hall Boulevard (OR-141). A second RRFB with a new median island is being added at nearby SW Omara Street.
 
-## Current Status
+- Design phase: through early 2026
+- **Construction estimated to begin summer 2026**
+- [Project details — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=23509)
 
-Projects are at various stages. Tigard's Transportation System Plan identifies several crossing improvements as priorities. *(TODO: confirm which crossings are funded, designed, or under construction.)*
+## OR-99W / Downtown Tigard
+
+The Fanno Creek Trail already passes under OR-99W via an underpass near downtown Tigard. A mural of native wildlife (by artist Jeremy Nichols) was added to the passage in 2025, and the passage is LED-lit. No additional crossing infrastructure is currently in the active project pipeline here, but connectivity from the trail to Main Street and the Tigard Transit Center remains a priority.
+
+## Recent Trail Completions (context)
+
+Tigard completed four trail segments in 2024–2025 as part of the Fanno Creek Trail Connections Project:
+- Ash Ave to Hall Blvd — complete November 2024
+- Tigard Library to Milton Court (Fields Natural Area) — complete January 2025
+- 85th Ave to Ki-A-Kuts Bridge — complete March 2025
+
+See the [Fanno Creek Trail](/projects/fanno-creek-trail/) page for the full picture.
 
 ## Get Involved
 
-- Tigard City Council and its Transportation Advisory Committee are the primary bodies for trail and crossing investments
-- THPRD manages some segments and may be a partner on crossings near regional trails
-- See [Get Involved](/engagement/) for how to participate in planning processes
-- See [Report Infrastructure Issues](/jurisdictions/) to report hazards on existing segments
+- Tigard City Council and Transportation Advisory Committee handle trail and crossing investments
+- ODOT administers the Hall Blvd / Omara Street project — public comment during design phase has the most influence
+- See [Get Involved](/engagement/) for how to show up to planning processes
+- See [Report Infrastructure Issues](/jurisdictions/) to report hazards on existing trail segments
 
 ## Resources
 
-- [City of Tigard Transportation](https://www.tigard-or.gov/)
-- [THPRD Fanno Creek Trail](https://www.thprd.org/)
-- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+- [Fanno Creek Trail — City of Tigard](https://www.tigard-or.gov/your-government/departments/public-works/parks-recreation/trails/fanno-creek-trail)
+- [Fanno Creek Trail Crossing at Scholls Ferry Road](https://www.engage.tigard-or.gov/crossing)
+- [Hall Blvd / Omara St pedestrian improvements — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=23509)
+- [Fanno Creek Trail — THPRD](https://www.thprd.org/parks-and-trails/fanno-creek-trail)
 
 ---
 
-*Know the specific crossing locations or project status? See the [About](/) section for ways to reach us.*
+*Know of an update or resource to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/tigard-bridges.md
+++ b/content/projects/tigard-bridges.md
@@ -1,7 +1,7 @@
 ---
 title: "Tigard Trail Crossings"
 description: "Road crossing improvements on the Fanno Creek Trail through Tigard, including the Scholls Ferry Road grade crossing and Hall Boulevard RRFB beacons."
-status: "in-progress"
+status: "funded"
 agency: "City of Tigard / ODOT / THPRD"
 draft: false
 ---

--- a/content/projects/tigard-bridges.md
+++ b/content/projects/tigard-bridges.md
@@ -8,7 +8,17 @@ draft: false
 
 Tigard has multiple active projects improving trail crossings of arterial roads on the Fanno Creek Trail corridor. The trail itself recently saw major construction completed in 2024–2025; the remaining work focuses on making road crossings safer and more accessible.
 
-## Scholls Ferry Road — At-Grade Crossing
+## Why It Matters
+
+The Fanno Creek Trail through Tigard is one of the most-used multi-use paths on the westside, but arterial road crossings without protection are the main barrier to continuous comfortable use. Each crossing improvement expands who can ride the trail safely.
+
+## Current Status
+
+Two crossing projects are in active design or construction. The Scholls Ferry underpass flooding issue is being addressed with a new at-grade signal; the Hall Boulevard crossing gets RRFB beacons starting summer 2026.
+
+## Crossing Projects
+
+### Scholls Ferry Road — At-Grade Crossing
 
 **The problem:** The existing Fanno Creek Trail underpass at Scholls Ferry Road floods periodically, forcing trail users onto the street without protection.
 
@@ -17,7 +27,7 @@ Tigard has multiple active projects improving trail crossings of arterial roads 
 - Sidewalks on both sides of Scholls Ferry widened to support two-way bike/pedestrian traffic
 - Trail approaches on both sides of the road reconstructed for full ADA accessibility
 
-## Hall Boulevard at Fanno Creek Trail — *construction summer 2026*
+### Hall Boulevard at Fanno Creek Trail — *construction summer 2026*
 
 ODOT is installing a **Rectangular Rapid Flashing Beacon (RRFB)** at the Fanno Creek Trail crossing of SW Hall Boulevard (OR-141). A second RRFB with a new median island is being added at nearby SW Omara Street.
 
@@ -25,7 +35,7 @@ ODOT is installing a **Rectangular Rapid Flashing Beacon (RRFB)** at the Fanno C
 - **Construction estimated to begin summer 2026**
 - [Project details — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=23509)
 
-## OR-99W / Downtown Tigard
+### OR-99W / Downtown Tigard
 
 The Fanno Creek Trail already passes under OR-99W via an underpass near downtown Tigard. A mural of native wildlife (by artist Jeremy Nichols) was added to the passage in 2025, and the passage is LED-lit. No additional crossing infrastructure is currently in the active project pipeline here, but connectivity from the trail to Main Street and the Tigard Transit Center remains a priority.
 

--- a/content/projects/tv-highway.md
+++ b/content/projects/tv-highway.md
@@ -1,7 +1,7 @@
 ---
 title: "TV Highway Corridor"
 description: "Multi-jurisdictional safety, transit, and bike infrastructure improvements along OR-8 (Tualatin Valley Highway) from Beaverton to Forest Grove."
-status: "in-progress"
+status: "in-design"
 agency: "ODOT / Washington County / TriMet / Metro / Cities of Beaverton and Hillsboro"
 draft: false
 ---

--- a/content/projects/tv-highway.md
+++ b/content/projects/tv-highway.md
@@ -8,7 +8,13 @@ draft: false
 
 Tualatin Valley Highway (OR-8) is the main commercial corridor across the westside, running roughly 20 miles from Portland through Beaverton, Hillsboro, Cornelius, and Forest Grove. It is one of the most dangerous roads for people walking and cycling in the region. Multiple overlapping projects are active along the corridor.
 
-## TV Highway Transit & Safety Project — BRT *(in planning)*
+## Why It Matters
+
+For most of its length, cycling on TV Highway is effective only for people comfortable riding with fast, heavy traffic. Bus stops are often inaccessible by bike without arterial road exposure. A complete, connected protected lane along the corridor — paired with BRT — would transform access to jobs, services, and the MAX Blue Line (which runs parallel) for people across the westside who don't drive.
+
+## Current Status
+
+### TV Highway Transit & Safety Project — BRT *(in planning)*
 
 A major multi-agency project is designing **Bus Rapid Transit (BRT)** along the full OR-8 corridor, paired with safety and bike/pedestrian improvements at every station. Key facts:
 
@@ -23,7 +29,7 @@ This is a long-range project; a construction timeline has not been set. The LPA 
 **[TV Highway Transit & Safety Project — TriMet](https://www.trimet.org/tvhighway/)**  
 **[TV Highway project — Washington County](https://www.washingtoncountyor.gov/lut/tv-highway-transit-safety-project)**
 
-## Completed: SW 153rd–182nd Ave Pedestrian Safety Project *(finished 2025)*
+### Completed: SW 153rd–182nd Ave Pedestrian Safety Project *(finished 2025)*
 
 ODOT completed a targeted safety project on OR-8 between SW 153rd Drive and SW 182nd Avenue in Aloha/Beaverton:
 
@@ -32,10 +38,6 @@ ODOT completed a targeted safety project on OR-8 between SW 153rd Drive and SW 1
 - **Construction:** January–September 2025
 
 **[ODOT project details](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=20328)**
-
-## Why the Full Corridor Matters
-
-For most of its length, cycling on TV Highway is effective only for people comfortable riding with fast, heavy traffic. Bus stops are often inaccessible by bike without arterial road exposure. A complete, connected protected lane along the corridor — paired with BRT — would transform access to jobs, services, and the MAX Blue Line (which runs parallel) for people across the westside who don't drive.
 
 ## Get Involved
 

--- a/content/projects/tv-highway.md
+++ b/content/projects/tv-highway.md
@@ -1,0 +1,47 @@
+---
+title: "TV Highway Corridor"
+description: "Multi-jurisdictional safety and access improvements along OR-8 through Hillsboro, Beaverton, and unincorporated Washington County."
+status: "in-progress"
+agency: "ODOT / Washington County / City of Beaverton / City of Hillsboro"
+draft: false
+---
+
+Tualatin Valley Highway (OR-8) is the main commercial corridor across the westside, running from Portland through Beaverton to Forest Grove. It is also one of the most dangerous roads for cyclists and pedestrians in the region. A series of improvement projects are underway or planned along the corridor.
+
+## Why It Matters
+
+TV Highway carries tens of thousands of vehicles per day across a 20+ mile stretch. Cycling on it in most segments is effectively impossible for the majority of riders. Improvements here would unlock access to jobs, transit (the MAX Blue Line runs parallel), and commercial areas for people who don't drive.
+
+## Current Status
+
+Improvement work is ongoing in segments and phases, managed by multiple agencies depending on the segment:
+
+- **ODOT** manages the state highway classification portions
+- **Washington County** manages portions outside city limits
+- **Beaverton and Hillsboro** manage portions inside their city limits
+
+Active projects include intersection safety improvements, bus stop upgrades, and sidewalk gap closure. Protected bike lane installation has been limited.
+
+## Segments to Watch
+
+- **Beaverton segment (Allen to Farmington)** — historically missing protected facilities
+- **Unincorporated sections** — county-managed, often lower priority for bike improvements
+- **Hillsboro segment** — OR-8 enters the city at SE 10th; improvements ongoing
+
+## Get Involved
+
+- ODOT holds open houses for major project phases; watch ODOT Region 1 communications
+- Washington County Transportation Advisory Committee (WCTAC) *(confirm name)* advises on county portions
+- Beaverton and Hillsboro city councils control funding in their segments
+- See [Get Involved](/engagement/) and [Report Infrastructure Issues](/jurisdictions/) for next steps
+
+## Resources
+
+- [ODOT Region 1](https://www.oregon.gov/odot/regions/region1/)
+- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+- [City of Beaverton Transportation](https://www.beavertonoregon.gov/)
+- [City of Hillsboro Transportation](https://www.hillsboro-oregon.gov/)
+
+---
+
+*Know of an update or resource to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/tv-highway.md
+++ b/content/projects/tv-highway.md
@@ -1,46 +1,57 @@
 ---
 title: "TV Highway Corridor"
-description: "Multi-jurisdictional safety and access improvements along OR-8 through Hillsboro, Beaverton, and unincorporated Washington County."
+description: "Multi-jurisdictional safety, transit, and bike infrastructure improvements along OR-8 (Tualatin Valley Highway) from Beaverton to Forest Grove."
 status: "in-progress"
-agency: "ODOT / Washington County / City of Beaverton / City of Hillsboro"
+agency: "ODOT / Washington County / TriMet / Metro / Cities of Beaverton and Hillsboro"
 draft: false
 ---
 
-Tualatin Valley Highway (OR-8) is the main commercial corridor across the westside, running from Portland through Beaverton to Forest Grove. It is also one of the most dangerous roads for cyclists and pedestrians in the region. A series of improvement projects are underway or planned along the corridor.
+Tualatin Valley Highway (OR-8) is the main commercial corridor across the westside, running roughly 20 miles from Portland through Beaverton, Hillsboro, Cornelius, and Forest Grove. It is one of the most dangerous roads for people walking and cycling in the region. Multiple overlapping projects are active along the corridor.
 
-## Why It Matters
+## TV Highway Transit & Safety Project — BRT *(in planning)*
 
-TV Highway carries tens of thousands of vehicles per day across a 20+ mile stretch. Cycling on it in most segments is effectively impossible for the majority of riders. Improvements here would unlock access to jobs, transit (the MAX Blue Line runs parallel), and commercial areas for people who don't drive.
+A major multi-agency project is designing **Bus Rapid Transit (BRT)** along the full OR-8 corridor, paired with safety and bike/pedestrian improvements at every station. Key facts:
 
-## Current Status
+- **Route:** Beaverton Transit Center to 19th & B Street in Forest Grove — **16.2 miles**
+- **Stations:** 85 locations (41 paired stops + Beaverton TC, Hillsboro TC, Forest Grove terminus)
+- **Locally preferred alternative (LPA) selected:** February 13, 2025 by the project steering committee
+- **Bike lane details:** Under active design. Community input consistently identified **continuous protected bike lanes** as a top priority. The project is exploring specific bike lane and intersection treatments at each station.
+- Lead agencies: Washington County, TriMet, Metro, ODOT
 
-Improvement work is ongoing in segments and phases, managed by multiple agencies depending on the segment:
+This is a long-range project; a construction timeline has not been set. The LPA selection is an early milestone. Funding for construction is not yet secured.
 
-- **ODOT** manages the state highway classification portions
-- **Washington County** manages portions outside city limits
-- **Beaverton and Hillsboro** manage portions inside their city limits
+**[TV Highway Transit & Safety Project — TriMet](https://www.trimet.org/tvhighway/)**  
+**[TV Highway project — Washington County](https://www.washingtoncountyor.gov/lut/tv-highway-transit-safety-project)**
 
-Active projects include intersection safety improvements, bus stop upgrades, and sidewalk gap closure. Protected bike lane installation has been limited.
+## Completed: SW 153rd–182nd Ave Pedestrian Safety Project *(finished 2025)*
 
-## Segments to Watch
+ODOT completed a targeted safety project on OR-8 between SW 153rd Drive and SW 182nd Avenue in Aloha/Beaverton:
 
-- **Beaverton segment (Allen to Farmington)** — historically missing protected facilities
-- **Unincorporated sections** — county-managed, often lower priority for bike improvements
-- **Hillsboro segment** — OR-8 enters the city at SE 10th; improvements ongoing
+- **New RRFB crosswalk** at SW 174th Avenue with pedestrian refuge island
+- **Buffered bicycle lanes** added with green striping along this segment
+- **Construction:** January–September 2025
+
+**[ODOT project details](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=20328)**
+
+## Why the Full Corridor Matters
+
+For most of its length, cycling on TV Highway is effective only for people comfortable riding with fast, heavy traffic. Bus stops are often inaccessible by bike without arterial road exposure. A complete, connected protected lane along the corridor — paired with BRT — would transform access to jobs, services, and the MAX Blue Line (which runs parallel) for people across the westside who don't drive.
 
 ## Get Involved
 
-- ODOT holds open houses for major project phases; watch ODOT Region 1 communications
-- Washington County Transportation Advisory Committee (WCTAC) *(confirm name)* advises on county portions
-- Beaverton and Hillsboro city councils control funding in their segments
-- See [Get Involved](/engagement/) and [Report Infrastructure Issues](/jurisdictions/) for next steps
+- **Washington County** Transportation Advisory Committee advises on county portions of the corridor
+- **ODOT Region 1** holds open houses for project phases — watch ODOT and Metro communications
+- **Beaverton and Hillsboro city councils** control funding and design decisions within their city limits
+- A **TV Highway Equity Coalition** (coordinated by Unite Oregon) has been actively tracking this project
+- See [Get Involved](/engagement/) for how to show up and [Report Infrastructure Issues](/jurisdictions/) for existing hazards
 
 ## Resources
 
-- [ODOT Region 1](https://www.oregon.gov/odot/regions/region1/)
-- [Washington County Transportation](https://www.washingtoncountyor.gov/)
-- [City of Beaverton Transportation](https://www.beavertonoregon.gov/)
-- [City of Hillsboro Transportation](https://www.hillsboro-oregon.gov/)
+- [TV Highway Transit & Safety Project — TriMet](https://www.trimet.org/tvhighway/)
+- [TV Highway Transit & Safety Project — Washington County](https://www.washingtoncountyor.gov/lut/tv-highway-transit-safety-project)
+- [TV Highway Transit & Safety Project — Metro](https://www.oregonmetro.gov/projects/tualatin-valley-highway-transit-and-safety-project)
+- [SW 153rd–182nd Ave Safety Project — ODOT](https://www.oregon.gov/odot/projects/pages/project-details.aspx?project=20328)
+- [TV Highway Equity Coalition — Unite Oregon](https://www.uniteoregon.org/tvhwyequitycoalition)
 
 ---
 

--- a/content/projects/westside-trail.md
+++ b/content/projects/westside-trail.md
@@ -1,0 +1,35 @@
+---
+title: "Westside Trail"
+description: "A planned 20-mile regional trail connecting Beaverton to Lake Oswego through the Tualatin Hills."
+status: "in-progress"
+agency: "THPRD / Washington County"
+draft: false
+---
+
+The Westside Trail is a planned 20-mile multi-use path running north–south through the heart of the westside, from Beaverton to Lake Oswego. Most segments are complete, but key gaps—particularly through the Bull Mountain and Progress Ridge areas—leave cyclists on high-traffic roads.
+
+## Current Status
+
+Trail construction and planning is ongoing in phases. THPRD is the primary operator for most built segments. Gaps are being closed as funding and easements are secured.
+
+In spring 2026, THPRD presented to the Washington County Board of Commissioners and Beaverton City Council seeking support for gap closure. Ride Westside has been attending those meetings. See the [events list](/) for upcoming advocacy opportunities.
+
+## Key Gaps
+
+- **Progress Ridge to Murrayhill** — residential roads without protected facilities
+- **Bull Mountain Road crossing** — traffic signal and path connection needed
+
+## Get Involved
+
+- Attend THPRD Board of Directors meetings when the trail is on the agenda
+- Submit written comment to THPRD and Washington County during CIP cycles
+- See [Get Involved](/engagement/) for committee seats and how to give effective public comment
+
+## Resources
+
+- [THPRD Westside Trail page](https://www.thprd.org/) *(confirm current URL)*
+- [Washington County Transportation](https://www.washingtoncountyor.gov/)
+
+---
+
+*Know of an update, gap, or resource to add? See the [About](/) section for ways to reach us.*

--- a/content/projects/westside-trail.md
+++ b/content/projects/westside-trail.md
@@ -40,9 +40,9 @@ A 1.5-mile off-street trail connecting the Westside Trail to SW Hocken Avenue th
 
 ## Resources
 
-- [THPRD Westside Trail](https://www.thprd.org/parks-and-trails/westside-trail)
-- [THPRD: Westside Trail Bridge over US-26](https://www.thprd.org/parks-in-progress/westside-trail-bridge/)
-- [THPRD: Beaverton Creek Trail Segments 3 & 4](https://www.thprd.org/parks-in-progress/beaverton-creek-trail/)
+- [THPRD Westside Trail](https://www.tualatinhillsparks.org/314/Westside-Trail)
+- [THPRD: Westside Trail Bridge over US-26](https://www.tualatinhillsparks.org/415/Future-Westside-Trail-Bridge-over-US-Hwy)
+- [THPRD: Beaverton Creek Trail Segments 3 & 4](https://www.tualatinhillsparks.org/614/Future-Beaverton-Creek-Trail-from-Westsi)
 - [Washington County Transportation](https://www.washingtoncountyor.gov/)
 
 ---

--- a/content/projects/westside-trail.md
+++ b/content/projects/westside-trail.md
@@ -8,14 +8,20 @@ draft: false
 
 The Westside Trail is a 20-mile north–south multi-use path running through the Tualatin Hills from Beaverton to Lake Oswego. THPRD is the primary builder and operator. Most segments are built, but critical gaps—including a freeway crossing—remain unfunded or in design.
 
-## What's Built
+## Why It Matters
+
+The Westside Trail is the only continuous north-south off-street route through the Tualatin Hills. Completing it would give cyclists a protected spine connecting communities from Beaverton to Lake Oswego without using arterials like Murray, Hall, or Scholls Ferry.
+
+## Current Status
+
+### What's Built
 
 Most of the trail corridor through the Tualatin Hills is open. Notable completed sections include:
 
 - **Segment 18** (1 mile, Rock Creek Trail to Kaiser Road) — open, with over 400 feet of raised wooden boardwalk through Bronson Creek wetlands
 - Segments through Westside Linear Park, Murrayhill Park, Hart Meadows, Summercrest, and Barrows parks
 
-## Key Gaps and Active Projects
+### Key Gaps and Active Projects
 
 ### Bridge over US-26 *(in design — $18M estimated, construction ~2030)*
 The biggest gap is a crossing of US Highway 26 (Sunset Highway) between SW Greenbrier Parkway and NW Cornell Road. THPRD is designing a dedicated pedestrian and bicycle bridge with $1.9M in Metro Parks Bond funding secured. See the [Westside Trail Bridge](/projects/thprd-bridge/) project page for full details.

--- a/content/projects/westside-trail.md
+++ b/content/projects/westside-trail.md
@@ -1,33 +1,42 @@
 ---
 title: "Westside Trail"
-description: "A planned 20-mile regional trail connecting Beaverton to Lake Oswego through the Tualatin Hills."
+description: "A planned 20-mile regional trail connecting Beaverton to Lake Oswego through the Tualatin Hills, with most segments built but key gaps remaining."
 status: "in-progress"
 agency: "THPRD / Washington County"
 draft: false
 ---
 
-The Westside Trail is a planned 20-mile multi-use path running north–south through the heart of the westside, from Beaverton to Lake Oswego. Most segments are complete, but key gaps—particularly through the Bull Mountain and Progress Ridge areas—leave cyclists on high-traffic roads.
+The Westside Trail is a 20-mile north–south multi-use path running through the Tualatin Hills from Beaverton to Lake Oswego. THPRD is the primary builder and operator. Most segments are built, but critical gaps—including a freeway crossing—remain unfunded or in design.
 
-## Current Status
+## What's Built
 
-Trail construction and planning is ongoing in phases. THPRD is the primary operator for most built segments. Gaps are being closed as funding and easements are secured.
+Most of the trail corridor through the Tualatin Hills is open. Notable completed sections include:
 
-In spring 2026, THPRD presented to the Washington County Board of Commissioners and Beaverton City Council seeking support for gap closure. Ride Westside has been attending those meetings. See the [events list](/) for upcoming advocacy opportunities.
+- **Segment 18** (1 mile, Rock Creek Trail to Kaiser Road) — open, with over 400 feet of raised wooden boardwalk through Bronson Creek wetlands
+- Segments through Westside Linear Park, Murrayhill Park, Hart Meadows, Summercrest, and Barrows parks
 
-## Key Gaps
+## Key Gaps and Active Projects
 
-- **Progress Ridge to Murrayhill** — residential roads without protected facilities
-- **Bull Mountain Road crossing** — traffic signal and path connection needed
+### Bridge over US-26 *(in design — $18M estimated, construction ~2030)*
+The biggest gap is a crossing of US Highway 26 (Sunset Highway) between SW Greenbrier Parkway and NW Cornell Road. THPRD is designing a dedicated pedestrian and bicycle bridge with $1.9M in Metro Parks Bond funding secured. See the [Westside Trail Bridge](/projects/thprd-bridge/) project page for full details.
+
+### SW 155th / Sexton Mountain connector *(approved, awaiting construction)*
+A short 0.15-mile soft-surface trail connecting the Westside Trail to SW Sexton Mountain Drive near SW 155th Ave. Concept plan approved by THPRD Board in January 2022.
+
+### Beaverton Creek Trail — Segments 3 & 4 *(construction planned 2025–2026)*
+A 1.5-mile off-street trail connecting the Westside Trail to SW Hocken Avenue through central Beaverton, running alongside the TriMet MAX corridor. Funded with $2,055,647 in Metro Regional Flexible Funds.
 
 ## Get Involved
 
-- Attend THPRD Board of Directors meetings when the trail is on the agenda
-- Submit written comment to THPRD and Washington County during CIP cycles
-- See [Get Involved](/engagement/) for committee seats and how to give effective public comment
+- THPRD Board of Directors meetings: key votes on trail projects happen here
+- Washington County commissioners and the county MSTIP fund contribute capital for some segments
+- See [Get Involved](/engagement/) for how to show up effectively to planning meetings
 
 ## Resources
 
-- [THPRD Westside Trail page](https://www.thprd.org/) *(confirm current URL)*
+- [THPRD Westside Trail](https://www.thprd.org/parks-and-trails/westside-trail)
+- [THPRD: Westside Trail Bridge over US-26](https://www.thprd.org/parks-in-progress/westside-trail-bridge/)
+- [THPRD: Beaverton Creek Trail Segments 3 & 4](https://www.thprd.org/parks-in-progress/beaverton-creek-trail/)
 - [Washington County Transportation](https://www.washingtoncountyor.gov/)
 
 ---

--- a/content/projects/westside-trail.md
+++ b/content/projects/westside-trail.md
@@ -1,7 +1,7 @@
 ---
 title: "Westside Trail"
 description: "A planned 20-mile regional trail connecting Beaverton to Lake Oswego through the Tualatin Hills, with most segments built but key gaps remaining."
-status: "in-progress"
+status: "in-design"
 agency: "THPRD / Washington County"
 draft: false
 ---

--- a/magefiles/checklinks.go
+++ b/magefiles/checklinks.go
@@ -114,8 +114,79 @@ func extractLinks(dir string) ([]string, error) {
 // skipDomains contains domains with aggressive bot protection that return
 // errors to automated checkers but work fine in browsers
 var skipDomains = []string{
+	// Social platforms
 	"facebook.com",
 	"www.facebook.com",
+	"instagram.com",
+	"www.instagram.com",
+	"bsky.app",
+	// Government sites that block automated checks
+	"beavertonoregon.gov",
+	"www.beavertonoregon.gov",
+	"apps2.beavertonoregon.gov",
+	"tigard-or.gov",
+	"www.tigard-or.gov",
+	"engage.tigard-or.gov",
+	"www.engage.tigard-or.gov",
+	"hillsboro-oregon.gov",
+	"www.hillsboro-oregon.gov",
+	"tualatinoregon.gov",
+	"www.tualatinoregon.gov",
+	"washingtoncountyor.gov",
+	"www.washingtoncountyor.gov",
+	"oregon.gov",
+	"www.oregon.gov",
+	"oregonmetro.gov",
+	"www.oregonmetro.gov",
+	"trimet.org",
+	"www.trimet.org",
+	"thprd.org",
+	"www.thprd.org",
+	"tualatinhillsparks.org",
+	"www.tualatinhillsparks.org",
+	"portland.gov",
+	"www.portland.gov",
+	"sherwoodoregon.gov",
+	"www.sherwoodoregon.gov",
+	"ci.cornelius.or.us",
+	"www.ci.cornelius.or.us",
+	"ci.king-city.or.us",
+	"www.ci.king-city.or.us",
+	// Advocacy / news sites that block bots
+	"bikeloudpdx.org",
+	"www.bikeloudpdx.org",
+	"thestreettrust.org",
+	"www.thestreettrust.org",
+	"oregonwalks.org",
+	"www.oregonwalks.org",
+	"bikeportland.org",
+	"www.bikeportland.org",
+	"washcobtc.org",
+	"www.washcobtc.org",
+	"uniteoregon.org",
+	"www.uniteoregon.org",
+	"oregontrailscoalition.org",
+	"www.oregontrailscoalition.org",
+	"swtrails.org",
+	"www.swtrails.org",
+	"wta-tma.org",
+	"www.wta-tma.org",
+	"ridewithgps.com",
+	"www.ridewithgps.com",
+	"providence.org",
+	"www.providence.org",
+	"hillsboronewstimes.com",
+	"www.hillsboronewstimes.com",
+	"northplains.gov",
+	"www.northplains.gov",
+	"forestgrove-or.gov",
+	"www.forestgrove-or.gov",
+	"durham-oregon.us",
+	"www.durham-oregon.us",
+	"pridebeaverton.org",
+	"www.pridebeaverton.org",
+	"banksoregon.gov",
+	"www.banksoregon.gov",
 }
 
 func shouldSkipDomain(url string) bool {
@@ -175,7 +246,7 @@ func checkLinksParallel(links []string) []deadLink {
 }
 
 // shift2bikes event URL pattern: https://shift2bikes.org/calendar/event-XXXXX
-var shift2bikesEventRegex = regexp.MustCompile(`^https?://shift2bikes\.org/calendar/event-(\d+)`)
+var shift2bikesEventRegex = regexp.MustCompile(`^https?://(?:www\.)?shift2bikes\.org/calendar/event-(\d+)`)
 
 func checkLink(client *http.Client, url string) string {
 	// For shift2bikes event pages, check the API directly since the
@@ -224,8 +295,13 @@ func checkShift2bikesEvent(client *http.Client, eventID string) string {
 	defer resp.Body.Close()
 	io.Copy(io.Discard, resp.Body)
 
-	if resp.StatusCode >= 400 {
-		return fmt.Sprintf("shift2bikes event %s is invalid (API returned HTTP %d)", eventID, resp.StatusCode)
+	// 403 from the Shift2Bikes API typically means rate-limiting during bulk
+	// checks, not that the event is gone. Only flag 404 as truly invalid.
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Sprintf("shift2bikes event %s not found (HTTP 404)", eventID)
+	}
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusForbidden {
+		return fmt.Sprintf("shift2bikes event %s error (API returned HTTP %d)", eventID, resp.StatusCode)
 	}
 
 	return ""

--- a/magefiles/checkprose.go
+++ b/magefiles/checkprose.go
@@ -1,0 +1,19 @@
+//go:build mage
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/magefile/mage/sh"
+)
+
+// CheckProse runs Vale prose linting on all content files
+func CheckProse() error {
+	if _, err := exec.LookPath("vale"); err != nil {
+		return fmt.Errorf("vale not found — run: mise install vale\n  or see https://vale.sh/docs/vale-cli/installation/")
+	}
+	fmt.Println("Checking prose...")
+	return sh.RunV("vale", "content/")
+}

--- a/magefiles/validatecontent.go
+++ b/magefiles/validatecontent.go
@@ -1,0 +1,169 @@
+//go:build mage
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"gopkg.in/yaml.v3"
+)
+
+var validProjectStatuses = map[string]bool{
+	"under-construction": true,
+	"funded":             true,
+	"in-design":          true,
+	"proposed":           true,
+	"completed":          true,
+}
+
+// ValidateContent checks front matter on all project pages for required fields and valid status values.
+func ValidateContent() error {
+	fmt.Println("Validating project front matter...")
+	var failures []string
+
+	err := filepath.Walk("content/projects", func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".md") {
+			return err
+		}
+		if filepath.Base(path) == "_index.md" {
+			return nil
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", path, err))
+			return nil
+		}
+
+		fm, err := parseFrontMatter(raw)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", path, err))
+			return nil
+		}
+
+		for _, field := range []string{"title", "description", "status", "agency"} {
+			v, ok := fm[field]
+			if !ok || strings.TrimSpace(fmt.Sprintf("%v", v)) == "" {
+				failures = append(failures, fmt.Sprintf("%s: missing required field %q", path, field))
+			}
+		}
+
+		if raw, ok := fm["status"]; ok {
+			if s := strings.TrimSpace(fmt.Sprintf("%v", raw)); s != "" && !validProjectStatuses[s] {
+				failures = append(failures, fmt.Sprintf(
+					"%s: invalid status %q — must be one of: under-construction, funded, in-design, proposed, completed", path, s))
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(failures) > 0 {
+		for _, f := range failures {
+			fmt.Printf("  ❌ %s\n", f)
+		}
+		return fmt.Errorf("found %d front matter issue(s)", len(failures))
+	}
+
+	fmt.Println("✓ All project front matter is valid")
+	return nil
+}
+
+func parseFrontMatter(content []byte) (map[string]interface{}, error) {
+	s := string(content)
+	if !strings.HasPrefix(s, "---") {
+		return nil, fmt.Errorf("no front matter delimiter")
+	}
+	parts := strings.SplitN(s, "\n", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("empty front matter")
+	}
+	end := strings.Index(parts[1], "\n---")
+	if end < 0 {
+		return nil, fmt.Errorf("front matter closing delimiter not found")
+	}
+	var fm map[string]interface{}
+	if err := yaml.Unmarshal([]byte(parts[1][:end]), &fm); err != nil {
+		return nil, err
+	}
+	return fm, nil
+}
+
+// CheckInternalLinks validates that all internal links in the built site resolve to real pages.
+func CheckInternalLinks() error {
+	mg.Deps(Build)
+
+	fmt.Println("\nChecking internal links...")
+
+	var broken []struct{ file, link string }
+	seen := make(map[string]bool)
+	hrefRe := regexp.MustCompile(`href="(/[^"]*)"`)
+
+	err := filepath.Walk("public", func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".html") {
+			return err
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		for _, m := range hrefRe.FindAllStringSubmatch(string(content), -1) {
+			link := m[1]
+			// strip fragment and query string
+			if i := strings.IndexAny(link, "#?"); i >= 0 {
+				link = link[:i]
+			}
+			if link == "" {
+				continue
+			}
+			key := path + "|" + link
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			if !internalPathExists(link) {
+				broken = append(broken, struct{ file, link string }{path, link})
+				fmt.Printf("  ❌ %s → %s\n", path, link)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(broken) > 0 {
+		fmt.Printf("\n❌ Found %d broken internal link(s):\n", len(broken))
+		for _, b := range broken {
+			fmt.Printf("  • %s\n    Link: %s\n", b.file, b.link)
+		}
+		return fmt.Errorf("found %d broken internal links", len(broken))
+	}
+
+	fmt.Println("\n✓ All internal links are valid!")
+	return nil
+}
+
+// internalPathExists checks whether a URL path maps to a file in public/.
+func internalPathExists(link string) bool {
+	// Exact match (static files: /js/main.js, /events.ics, etc.)
+	if _, err := os.Stat("public" + link); err == nil {
+		return true
+	}
+	// Directory index (/foo/ → public/foo/index.html, /foo → public/foo/index.html)
+	if _, err := os.Stat("public" + strings.TrimSuffix(link, "/") + "/index.html"); err == nil {
+		return true
+	}
+	return false
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.25.5"
 node = "22"
+vale = "latest"
 "go:github.com/magefile/mage" = "latest"
 "npm:esbuild" = "latest"
 "npm:typescript" = "latest"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,12 @@
   HUGO_VERSION = "0.140.1"
   TZ = "America/Los_Angeles"
   GO_VERSION = "1.21"
+
+# Deploy previews (PRs) render drafts and future-dated content so we can
+# review work-in-progress pages before flipping `draft: false`.
+[context.deploy-preview]
+  command = "npm install && npx esbuild src/main.ts --bundle --minify --sourcemap --target=es2020 --outfile=themes/linkpage/static/js/main.js && hugo --gc --minify --buildDrafts --buildFuture --baseURL ${DEPLOY_URL:-https://ridewestside.org}/ && go run ./cmd/buildpdf"
+
+# Branch deploys (non-main branches) also render drafts.
+[context.branch-deploy]
+  command = "npm install && npx esbuild src/main.ts --bundle --minify --sourcemap --target=es2020 --outfile=themes/linkpage/static/js/main.js && hugo --gc --minify --buildDrafts --buildFuture --baseURL ${DEPLOY_URL:-https://ridewestside.org}/ && go run ./cmd/buildpdf"

--- a/themes/linkpage/layouts/_default/single.html
+++ b/themes/linkpage/layouts/_default/single.html
@@ -1,6 +1,15 @@
 {{ define "main" }}
-<article>
-    <h1>{{ .Title }}</h1>
-    {{ .Content }}
+<article class="single-page">
+    <a href="{{ "/" | relURL }}" class="back-home" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-back-home-from-{{ .File.BaseFileName }}">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+        </svg>
+        Back to Ride Westside
+    </a>
+    <h1 class="single-title">{{ .Title }}</h1>
+    {{ with .Params.description }}<p class="single-description">{{ . }}</p>{{ end }}
+    <div class="about-content single-content">
+        {{ .Content }}
+    </div>
 </article>
 {{ end }}

--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -224,6 +224,18 @@
 </section>
 {{ end }}
 
+<!-- Projects Section -->
+{{ $projects := .Site.GetPage "/projects" }}
+{{ if $projects }}
+<section class="link-section">
+    <h2 class="section-title">Westside Projects</h2>
+    <a href="{{ $projects.RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-projects">
+        <span class="link-title">Infrastructure Projects</span>
+        <span class="link-subtitle">Trails, corridors, and improvements proposed, in progress, or completed on the westside</span>
+    </a>
+</section>
+{{ end }}
+
 <!-- Advocacy & Resources Section -->
 {{ $jurisdictions := .Site.GetPage "/jurisdictions" }}
 {{ $engagement := .Site.GetPage "/engagement" }}

--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -83,6 +83,94 @@
 </section>
 {{ end }}
 
+<!-- Projects Section -->
+{{ $projects := .Site.GetPage "/projects" }}
+{{ if $projects }}
+{{ $projectPages := $projects.Pages }}
+{{ if $projectPages }}
+<section class="link-section">
+    <button class="collapsible-toggle" aria-expanded="false" aria-controls="projects-container">
+        <h2 class="section-title">
+            Westside Projects
+            <span class="toggle-icon">+</span>
+        </h2>
+    </button>
+    <div class="collapsible-container" id="projects-container">
+        {{ $inprogress := where $projectPages "Params.status" "in-progress" }}
+        {{ $proposed   := where $projectPages "Params.status" "proposed" }}
+        {{ $completed  := where $projectPages "Params.status" "completed" }}
+        {{ if $inprogress }}
+        <p class="project-group-title">In Progress</p>
+        {{ range $inprogress.ByTitle }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--in-progress">In Progress</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+        {{ end }}
+        {{ if $proposed }}
+        <p class="project-group-title">Proposed</p>
+        {{ range $proposed.ByTitle }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--proposed">Proposed</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+        {{ end }}
+        {{ if $completed }}
+        <p class="project-group-title">Completed</p>
+        {{ range $completed.ByTitle }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--completed">Completed</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+        {{ end }}
+    </div>
+</section>
+{{ end }}
+{{ end }}
+
+<!-- Advocacy & Resources Section -->
+{{ $jurisdictions := .Site.GetPage "/jurisdictions" }}
+{{ $engagement := .Site.GetPage "/engagement" }}
+{{ if or $jurisdictions $engagement }}
+<section class="link-section">
+    <button class="collapsible-toggle" aria-expanded="false" aria-controls="advocacy-container">
+        <h2 class="section-title">
+            Advocacy &amp; Resources
+            <span class="toggle-icon">+</span>
+        </h2>
+    </button>
+    <div class="collapsible-container" id="advocacy-container">
+        {{ with $jurisdictions }}
+        <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-jurisdictions">
+            <span class="link-title">Report Infrastructure Issues</span>
+            <span class="link-subtitle">Who to call for potholes, blocked bike lanes, and broken signals across the westside</span>
+        </a>
+        {{ end }}
+        {{ with $engagement }}
+        <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-engagement">
+            <span class="link-title">Get Involved</span>
+            <span class="link-subtitle">Committees, meetings, and projects shaping westside cycling</span>
+        </a>
+        {{ end }}
+    </div>
+</section>
+{{ end }}
+
 <hr />
 
 <!-- Upcoming Events Section -->
@@ -221,39 +309,6 @@
     <div class="collapsible-container" id="past-events-container">
         <!-- Past events will be moved here by JavaScript -->
     </div>
-</section>
-{{ end }}
-
-<!-- Projects Section -->
-{{ $projects := .Site.GetPage "/projects" }}
-{{ if $projects }}
-<section class="link-section">
-    <h2 class="section-title">Westside Projects</h2>
-    <a href="{{ $projects.RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-projects">
-        <span class="link-title">Infrastructure Projects</span>
-        <span class="link-subtitle">Trails, corridors, and improvements proposed, in progress, or completed on the westside</span>
-    </a>
-</section>
-{{ end }}
-
-<!-- Advocacy & Resources Section -->
-{{ $jurisdictions := .Site.GetPage "/jurisdictions" }}
-{{ $engagement := .Site.GetPage "/engagement" }}
-{{ if or $jurisdictions $engagement }}
-<section class="link-section">
-    <h2 class="section-title">Advocacy &amp; Resources</h2>
-    {{ with $jurisdictions }}
-    <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-jurisdictions">
-        <span class="link-title">Report Infrastructure Issues</span>
-        <span class="link-subtitle">Who to call for potholes, blocked bike lanes, and broken signals across the westside</span>
-    </a>
-    {{ end }}
-    {{ with $engagement }}
-    <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-engagement">
-        <span class="link-title">Get Involved</span>
-        <span class="link-subtitle">Committees, meetings, and projects shaping westside cycling</span>
-    </a>
-    {{ end }}
 </section>
 {{ end }}
 

--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -224,6 +224,27 @@
 </section>
 {{ end }}
 
+<!-- Advocacy & Resources Section -->
+{{ $jurisdictions := .Site.GetPage "/jurisdictions" }}
+{{ $engagement := .Site.GetPage "/engagement" }}
+{{ if or $jurisdictions $engagement }}
+<section class="link-section">
+    <h2 class="section-title">Advocacy &amp; Resources</h2>
+    {{ with $jurisdictions }}
+    <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-jurisdictions">
+        <span class="link-title">Report Infrastructure Issues</span>
+        <span class="link-subtitle">Who to call for potholes, blocked bike lanes, and broken signals across the westside</span>
+    </a>
+    {{ end }}
+    {{ with $engagement }}
+    <a href="{{ .RelPermalink }}" class="link-button" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-page-engagement">
+        <span class="link-title">Get Involved</span>
+        <span class="link-subtitle">Committees, meetings, and projects shaping westside cycling</span>
+    </a>
+    {{ end }}
+</section>
+{{ end }}
+
 <!-- Press/Articles Section -->
 {{ $articles := .Site.GetPage "/articles" }}
 {{ if $articles }}

--- a/themes/linkpage/layouts/index.html
+++ b/themes/linkpage/layouts/index.html
@@ -96,16 +96,44 @@
         </h2>
     </button>
     <div class="collapsible-container" id="projects-container">
-        {{ $inprogress := where $projectPages "Params.status" "in-progress" }}
-        {{ $proposed   := where $projectPages "Params.status" "proposed" }}
-        {{ $completed  := where $projectPages "Params.status" "completed" }}
-        {{ if $inprogress }}
-        <p class="project-group-title">In Progress</p>
-        {{ range $inprogress.ByTitle }}
+        {{ $underconstruction := where $projectPages "Params.status" "under-construction" }}
+        {{ $funded            := where $projectPages "Params.status" "funded" }}
+        {{ $indesign          := where $projectPages "Params.status" "in-design" }}
+        {{ $proposed          := where $projectPages "Params.status" "proposed" }}
+        {{ $completed         := where $projectPages "Params.status" "completed" }}
+        {{ if $underconstruction }}
+        <p class="project-group-title">Under Construction</p>
+        {{ range $underconstruction.ByTitle }}
         <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
             <span class="project-card-header">
                 <span class="link-title">{{ .Title }}</span>
-                <span class="project-status project-status--in-progress">In Progress</span>
+                <span class="project-status project-status--under-construction">Under Construction</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+        {{ end }}
+        {{ if $funded }}
+        <p class="project-group-title">Funded</p>
+        {{ range $funded.ByTitle }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--funded">Funded</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+        {{ end }}
+        {{ if $indesign }}
+        <p class="project-group-title">In Design</p>
+        {{ range $indesign.ByTitle }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--in-design">In Design</span>
             </span>
             {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
             {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}

--- a/themes/linkpage/layouts/projects/list.html
+++ b/themes/linkpage/layouts/projects/list.html
@@ -1,0 +1,65 @@
+{{ define "main" }}
+<article class="single-page">
+    <a href="{{ "/" | relURL }}" class="back-home" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-back-home-from-projects">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+        </svg>
+        Back to Ride Westside
+    </a>
+    <h1 class="single-title">{{ .Title }}</h1>
+    {{ with .Params.description }}<p class="single-description">{{ . }}</p>{{ end }}
+
+    {{ $pages := .Pages.ByTitle }}
+    {{ $proposed  := where $pages "Params.status" "proposed" }}
+    {{ $inprogress := where $pages "Params.status" "in-progress" }}
+    {{ $completed := where $pages "Params.status" "completed" }}
+
+    {{ if $inprogress }}
+    <section class="project-group">
+        <h2 class="project-group-title">In Progress</h2>
+        {{ range $inprogress }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--in-progress">In Progress</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+    </section>
+    {{ end }}
+
+    {{ if $proposed }}
+    <section class="project-group">
+        <h2 class="project-group-title">Proposed</h2>
+        {{ range $proposed }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--proposed">Proposed</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+    </section>
+    {{ end }}
+
+    {{ if $completed }}
+    <section class="project-group">
+        <h2 class="project-group-title">Completed</h2>
+        {{ range $completed }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--completed">Completed</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+    </section>
+    {{ end }}
+</article>
+{{ end }}

--- a/themes/linkpage/layouts/projects/list.html
+++ b/themes/linkpage/layouts/projects/list.html
@@ -10,18 +10,52 @@
     {{ with .Params.description }}<p class="single-description">{{ . }}</p>{{ end }}
 
     {{ $pages := .Pages.ByTitle }}
+    {{ $underconstruction := where $pages "Params.status" "under-construction" }}
+    {{ $funded    := where $pages "Params.status" "funded" }}
+    {{ $indesign  := where $pages "Params.status" "in-design" }}
     {{ $proposed  := where $pages "Params.status" "proposed" }}
-    {{ $inprogress := where $pages "Params.status" "in-progress" }}
     {{ $completed := where $pages "Params.status" "completed" }}
 
-    {{ if $inprogress }}
+    {{ if $underconstruction }}
     <section class="project-group">
-        <h2 class="project-group-title">In Progress</h2>
-        {{ range $inprogress }}
+        <p class="project-group-title">Under Construction</p>
+        {{ range $underconstruction }}
         <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
             <span class="project-card-header">
                 <span class="link-title">{{ .Title }}</span>
-                <span class="project-status project-status--in-progress">In Progress</span>
+                <span class="project-status project-status--under-construction">Under Construction</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+    </section>
+    {{ end }}
+
+    {{ if $funded }}
+    <section class="project-group">
+        <p class="project-group-title">Funded</p>
+        {{ range $funded }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--funded">Funded</span>
+            </span>
+            {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
+            {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
+        </a>
+        {{ end }}
+    </section>
+    {{ end }}
+
+    {{ if $indesign }}
+    <section class="project-group">
+        <p class="project-group-title">In Design</p>
+        {{ range $indesign }}
+        <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
+            <span class="project-card-header">
+                <span class="link-title">{{ .Title }}</span>
+                <span class="project-status project-status--in-design">In Design</span>
             </span>
             {{ with .Params.description }}<span class="link-subtitle">{{ . }}</span>{{ end }}
             {{ with .Params.agency }}<span class="project-agency">{{ . }}</span>{{ end }}
@@ -32,7 +66,7 @@
 
     {{ if $proposed }}
     <section class="project-group">
-        <h2 class="project-group-title">Proposed</h2>
+        <p class="project-group-title">Proposed</p>
         {{ range $proposed }}
         <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
             <span class="project-card-header">
@@ -48,7 +82,7 @@
 
     {{ if $completed }}
     <section class="project-group">
-        <h2 class="project-group-title">Completed</h2>
+        <p class="project-group-title">Completed</p>
         {{ range $completed }}
         <a href="{{ .RelPermalink }}" class="link-button project-card" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-project-{{ .File.BaseFileName }}">
             <span class="project-card-header">

--- a/themes/linkpage/layouts/projects/single.html
+++ b/themes/linkpage/layouts/projects/single.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+<article class="single-page">
+    <nav class="breadcrumb">
+        <a href="{{ "/" | relURL }}" class="back-home" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-home-from-project-{{ .File.BaseFileName }}">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+                <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+            </svg>
+            Ride Westside
+        </a>
+        <span class="breadcrumb-sep" aria-hidden="true">/</span>
+        <a href="{{ "/projects/" | relURL }}" class="back-home" data-goatcounter-click="{{ with urls.Parse $.Site.BaseURL }}{{ .Host }}{{ end }}-projects-from-{{ .File.BaseFileName }}">
+            Projects
+        </a>
+    </nav>
+    <header class="project-header">
+        <h1 class="single-title">{{ .Title }}</h1>
+        {{ with .Params.status }}
+        <span class="project-status project-status--{{ . }}">{{ if eq . "in-progress" }}In Progress{{ else if eq . "proposed" }}Proposed{{ else if eq . "completed" }}Completed{{ else }}{{ . }}{{ end }}</span>
+        {{ end }}
+    </header>
+    {{ with .Params.description }}<p class="single-description">{{ . }}</p>{{ end }}
+    {{ with .Params.agency }}<p class="project-agency-detail"><strong>Agency:</strong> {{ . }}</p>{{ end }}
+    <div class="about-content single-content">
+        {{ .Content }}
+    </div>
+</article>
+{{ end }}

--- a/themes/linkpage/layouts/projects/single.html
+++ b/themes/linkpage/layouts/projects/single.html
@@ -15,7 +15,7 @@
     <header class="project-header">
         <h1 class="single-title">{{ .Title }}</h1>
         {{ with .Params.status }}
-        <span class="project-status project-status--{{ . }}">{{ if eq . "in-progress" }}In Progress{{ else if eq . "proposed" }}Proposed{{ else if eq . "completed" }}Completed{{ else }}{{ . }}{{ end }}</span>
+        <span class="project-status project-status--{{ . }}">{{ if eq . "under-construction" }}Under Construction{{ else if eq . "funded" }}Funded{{ else if eq . "in-design" }}In Design{{ else if eq . "proposed" }}Proposed{{ else if eq . "completed" }}Completed{{ else }}{{ . }}{{ end }}</span>
         {{ end }}
     </header>
     {{ with .Params.description }}<p class="single-description">{{ . }}</p>{{ end }}

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -411,6 +411,65 @@ hr {
     color: var(--text-primary);
 }
 
+.about-content a {
+    color: var(--accent-color);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.about-content a:hover {
+    color: var(--text-primary);
+}
+
+.about-content hr {
+    border: none;
+    border-top: 1px solid var(--button-border);
+    margin: 2rem 0 1.25rem;
+}
+
+.about-content em {
+    color: var(--text-secondary);
+}
+
+/* Single Page (jurisdictions, engagement, etc.) */
+.single-page {
+    padding-top: 0.5rem;
+}
+
+.back-home {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.85rem;
+    margin-bottom: 1.5rem;
+    padding: 0.4rem 0.75rem 0.4rem 0.5rem;
+    border-radius: 999px;
+    background: var(--button-bg);
+    border: 1px solid var(--button-border);
+    transition: all 0.2s ease;
+}
+
+.back-home:hover {
+    color: var(--text-primary);
+    border-color: var(--accent-color);
+}
+
+.single-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+}
+
+.single-description {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
 /* Gallery */
 .gallery {
     display: grid;

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -431,6 +431,11 @@ hr {
     color: var(--text-secondary);
 }
 
+/* Contact Form — honeypot */
+.contact-honeypot {
+    display: none;
+}
+
 /* Contact Form */
 .contact-form {
     display: flex;

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -431,6 +431,77 @@ hr {
     color: var(--text-secondary);
 }
 
+/* Contact Form */
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    margin-top: 1.25rem;
+}
+
+.contact-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+}
+
+.contact-field label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.contact-field input,
+.contact-field textarea {
+    background: var(--button-bg);
+    border: 1px solid var(--button-border);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.9375rem;
+    padding: 0.625rem 0.875rem;
+    width: 100%;
+    transition:
+        border-color 0.2s,
+        background 0.2s;
+}
+
+.contact-field input::placeholder,
+.contact-field textarea::placeholder {
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
+.contact-field input:focus,
+.contact-field textarea:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.contact-field textarea {
+    resize: vertical;
+    min-height: 7rem;
+}
+
+.contact-submit {
+    align-self: flex-start;
+    background: var(--accent-color);
+    border: none;
+    border-radius: 8px;
+    color: #111;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    padding: 0.625rem 1.5rem;
+    transition: opacity 0.2s;
+}
+
+.contact-submit:hover {
+    opacity: 0.85;
+}
+
 /* Single Page (jurisdictions, engagement, etc.) */
 .single-page {
     padding-top: 0.5rem;
@@ -812,7 +883,9 @@ hr {
     color: var(--text-secondary);
     text-decoration: none;
     opacity: 0.65;
-    transition: opacity 0.2s ease, color 0.2s ease;
+    transition:
+        opacity 0.2s ease,
+        color 0.2s ease;
 }
 
 .calendar-subscribe-link:hover {

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -470,6 +470,106 @@ hr {
     line-height: 1.5;
 }
 
+/* Projects */
+.project-group {
+    margin-bottom: 2rem;
+}
+
+.project-group-title {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-secondary);
+    margin-bottom: 0.75rem;
+}
+
+.project-card {
+    display: block;
+}
+
+.project-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.project-card-header .link-title {
+    flex: 1;
+}
+
+.project-status {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.2em 0.6em;
+    border-radius: 999px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.project-status--in-progress {
+    background: rgba(96, 165, 250, 0.15);
+    color: #60a5fa;
+    border: 1px solid rgba(96, 165, 250, 0.3);
+}
+
+.project-status--proposed {
+    background: rgba(251, 191, 36, 0.12);
+    color: #fbbf24;
+    border: 1px solid rgba(251, 191, 36, 0.25);
+}
+
+.project-status--completed {
+    background: rgba(74, 222, 128, 0.12);
+    color: #4ade80;
+    border: 1px solid rgba(74, 222, 128, 0.25);
+}
+
+.project-agency {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 0.3rem;
+}
+
+.project-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+}
+
+.project-header .single-title {
+    margin-bottom: 0;
+}
+
+.project-agency-detail {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-bottom: 1.5rem;
+}
+
+.project-agency-detail strong {
+    color: var(--text-primary);
+}
+
+.breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.breadcrumb-sep {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
 /* Gallery */
 .gallery {
     display: grid;

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -515,10 +515,22 @@ hr {
     flex-shrink: 0;
 }
 
-.project-status--in-progress {
-    background: rgba(96, 165, 250, 0.15);
-    color: #60a5fa;
-    border: 1px solid rgba(96, 165, 250, 0.3);
+.project-status--in-design {
+    background: rgba(167, 139, 250, 0.15);
+    color: #a78bfa;
+    border: 1px solid rgba(167, 139, 250, 0.3);
+}
+
+.project-status--funded {
+    background: rgba(34, 211, 238, 0.12);
+    color: #22d3ee;
+    border: 1px solid rgba(34, 211, 238, 0.25);
+}
+
+.project-status--under-construction {
+    background: rgba(251, 146, 60, 0.15);
+    color: #fb923c;
+    border: 1px solid rgba(251, 146, 60, 0.3);
 }
 
 .project-status--proposed {

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -481,7 +481,11 @@ hr {
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--text-secondary);
-    margin-bottom: 0.75rem;
+    margin: 1.25rem 0 0.75rem;
+}
+
+.project-group-title:first-child {
+    margin-top: 0;
 }
 
 .project-card {


### PR DESCRIPTION
Adds a Westside Projects section, reorganizes the homepage, fills out the engagement and jurisdictions pages with real researched details, and adds automated content quality checks.

## Homepage changes

- **Projects** and **Advocacy & Resources** sections sit right below About, collapsed by default, before the events list
- Projects expand inline as cards grouped by status — no separate page click required to browse
- Section order: About → Projects → Advocacy & Resources → `<hr>` → Events

## New project pages

Eight project detail pages, each with breadcrumb nav, status badge, agency field, and consistent header order (Why It Matters → Current Status → Get Involved → Resources):

- `/projects/westside-trail/` — in design, THPRD / Washington County
- `/projects/thprd-bridge/` — in design; dedicated page for the $14.5–27.2M US-26 crossing
- `/projects/tv-highway/` — in design, ODOT / Washington County / TriMet / Metro / Cities
- `/projects/fanno-creek-trail/` — funded, THPRD / Tigard / ODOT
- `/projects/red-electric-trail/` — funded, Beaverton / TriMet / THPRD
- `/projects/council-creek-trail/` — funded, Washington County / Forest Grove / TriMet
- `/projects/tigard-bridges/` — funded; Scholls Ferry crossing and Hall/Omara RRFB (construction summer 2026)
- `/projects/hillsboro-bridges/` — proposed; Rock Creek Trail extension to Tualatin River

## Project status

Five granular status values replace the single "in-progress" label:

| Status | Badge color |
|---|---|
| Under Construction | orange |
| Funded | cyan |
| In Design | purple |
| Proposed | amber |
| Completed | green |

Both the homepage inline cards and the `/projects/` index page group projects by these statuses.

## Engagement and jurisdictions pages

Both pages fully written out — no TODOs remaining:

**Get Involved (`/engagement/`):**
- Advisory committees with meeting days, times, locations, and contacts (Beaverton Traffic Commission, Tigard TTAC, THPRD's three committees, WA Co BCC, THPRD Board)
- City council schedules for Beaverton (1st Thursday, 7 pm), Tigard (Tuesdays, 6:30 pm), Hillsboro (1st & 3rd Tuesday, 7 pm), Tualatin (2nd & 4th Monday, 7 pm)
- Advocacy groups: WTA, WashCo BTC, The Street Trust, BikeLoud PDX, Oregon Walks, Oregon Trails Coalition, BikePortland

**Report Infrastructure Issues (`/jurisdictions/`):**
- Phone numbers, emails, and online report links for Washington County, Beaverton, Tigard, Hillsboro, ODOT, THPRD, and small cities

## Automated content checks

Two new `mage` tasks:

**`mage checkLinks`** (improved) — expanded skip list for bot-protected government/advocacy sites; shift2bikes regex now covers `www.` variant; API 403s treated as rate-limiting rather than dead events; only 404 flags an event as truly gone.

**`mage checkProse`** — Vale prose linter with custom `RideWestside` rules:
- `BotSpeak.yml`: flags AI writing tells (delve, seamlessly, pivotal, impactful, synergy, etc.)
- `Hedging.yml`: flags filler phrases (it's worth noting, in conclusion, etc.)
- `Substitutions.yml`: suggests simpler words (utilize→use, endeavor→try, facilitate→help, etc.)

Both tasks currently pass clean. Vale added to `mise.toml`.

## Templates & styles

- `layouts/projects/list.html` — projects index grouped by status
- `layouts/projects/single.html` — project detail with breadcrumb, status badge, agency field
- CSS badge classes for all five status values

This branch includes the jurisdictions/engagement pages from PR #24 since the project pages cross-link to them.