### PR TITLE
Add Live Music Ride with Shantel Fitz and Chai Stop (6/27)

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -775,4 +775,12 @@ events:
     end: "Beaverton"
     tags: [ride, family-friendly]
 
+  - title: "6/27 Live Music Ride (Shantel Fitz) with a Chai Stop"
+    date: "June 27, 2026"
+    url: "https://www.shift2bikes.org/calendar/event-24419"
+    start: "Beaverton"
+    end: "Beaverton"
+    start_address: "12375 SW 5th St, Beaverton, OR 97005"
+    tags: [ride, music]
+
 ---


### PR DESCRIPTION
New ride from Beaverton Central Library ending at 503 Records for an
in-store performance by Shantel Fitz, with a Fly Chai stop en route.