### PR TITLE
Add 7/11 Data Center Bike Tour (Hillsboro)

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -783,4 +783,10 @@ events:
     start_address: "12375 SW 5th St, Beaverton, OR 97005"
     tags: [ride, music]
 
+  - title: "7/11 Data Center Bike Tour"
+    date: "July 11, 2026"
+    start: "Hillsboro"
+    start_address: "Pavillion Park, Hillsboro, OR"
+    tags: [ride, cause, not-rws]
+
 ---


### PR DESCRIPTION
Community ride organized by 350PDX, OR Defiance Alliance, and PDX DSA touring data center sites in the Hillsboro area. ~19 miles, MAX accessible, starting at Pavillion Park near Orenco Station.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A4rEE5vPejRyrMLjYznNa2