### PR TITLE
Add 7/19 BIKETOWN World Record E-bike Ride

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -789,4 +789,12 @@ events:
     start_address: "Pavillion Park, Hillsboro, OR"
     tags: [ride, cause, not-rws]
 
+  - title: "7/19 BIKETOWN World Record E-bike Ride"
+    date: "July 19, 2026"
+    url: "https://axiomeventproductions.regfox.com/biketown-world-record"
+    start: "Portland"
+    end: "Portland"
+    start_address: "Naito Parkway & SW Salmon St, Portland, OR"
+    tags: [ride, not-rws, family-friendly]
+
 ---


### PR DESCRIPTION
Adds the BIKETOWN 10th anniversary Guinness World Records e-bike ride to the events list.

- **Date:** July 19, 2026
- **Start:** Naito Parkway & SW Salmon St, Portland
- **Tags:** `ride`, `not-rws`, `family-friendly`
- **URL:** https://axiomeventproductions.regfox.com/biketown-world-record

2-mile waterfront loop (Naito Pkwy → Tilikum Bridge → Eastbank Esplanade). Goal is to break Seattle's record of 405 e-bikes. Personal e-bikes, BIKETOWN bikes, and pedal bikes all welcome. First 1,000 participants get complimentary entry to Portland Pride Festival.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4rEE5vPejRyrMLjYznNa2)_