### PR TITLE
Link Beaverton Murals photo giveaway page from the main page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ Recurring series (happy hours, etc.) go in the separate `recurring:` list instea
 | `start_time` | No | 12-hour clock string, e.g. `"4:30 PM"`. When set, the generated calendar (`layouts/index.ics`) renders the event as a timed entry (parsed as America/Los_Angeles) instead of an all-day one. Doesn't affect the on-page card, only the `.ics` export |
 | `end_time` | No | 12-hour clock string, e.g. `"7:00 PM"`. Only used if `start_time` is also set; adds a `DTEND` to the calendar entry. An event with `start_time` but no `end_time` gets a `DTSTART` only |
 | `tags` | No | YAML list of tag strings. Rendered as clickable filter chips on the card. See tag reference below |
+| `info_url` | No | Link to a related page (e.g. a giveaway rules page under `content/events/`, or an external URL). Renders a secondary button styled like Route |
+| `info_label` | No | Button label for `info_url`. Defaults to "More Info" if omitted |
 
 ### Tags
 

--- a/content/events.md
+++ b/content/events.md
@@ -326,6 +326,8 @@ events:
     end: "Beaverton"
     start_address: "12725 SW Millikan Way, Beaverton, OR 97005"
     tags: [ride, family-friendly]
+    info_url: "/events/beavertonmuralspublicart/"
+    info_label: "Photo Giveaway"
 
 recurring:
   # Beaverton Bike Happy Hours - 2nd and 4th Monday

--- a/content/events/BeavertonMuralsPublicArt/index.md
+++ b/content/events/BeavertonMuralsPublicArt/index.md
@@ -1,0 +1,37 @@
+---
+title: "Beaverton Murals and Public Art Ride Photo Giveaway"
+description: "Official rules for the Beaverton Murals and Public Art Ride photo giveaway."
+draft: false
+---
+
+Share what you discover on the Beaverton Murals and Public Art Ride for a chance to win one of **three $10 Fly Chai gift cards!**
+
+## How to Enter
+
+Participate in the Beaverton Murals and Public Art Ride on 8/23/2026 and post a photo of local art from the ride to your **Instagram feed or Story**.
+
+Include the hashtag:
+
+**#BeavertonArtDrawing**
+
+Entries must be posted by **11:59 p.m. on August 24, 2026**.
+
+After entries close, we’ll compile all eligible entries and randomly select three winners. Each winner will receive a **$10 gift card to Fly Chai**.
+
+## Giveaway Rules
+
+**Eligibility:** The giveaway is open to participants in the Beaverton Murals and Public Art Ride. No residency requirement. Participants under 18 must have permission from a parent or guardian to enter. No purchase is necessary.
+
+**How to enter:** Post a photo of local art taken during the Beaverton Murals and Public Art Ride to your Instagram feed or Story and include **#BeavertonArtDrawing**. Your post or Story must be visible to Ride Westside so that we can verify your entry.
+
+**Entry limit:** One entry per person.
+
+**Deadline:** Entries must be posted by **11:59 p.m. on August 24, 2026**.
+
+**Prizes:** Three winners will each receive one **$10 Fly Chai gift card**.
+
+**Winner selection:** After the entry period closes, all eligible entrants will be collected and three winners will be selected at random. Winners will be contacted through Instagram.
+
+Participants are not required to express any particular opinion about the artwork, Ride Westside, the Beaverton Arts Commission, Fly Chai, or any other organization or business in order to enter. This giveaway is organized by volunteers with Ride Westside.
+
+This promotion is in no way sponsored, endorsed, administered by, or associated with Instagram. By participating, entrants release Instagram from any responsibility related to the promotion.

--- a/themes/linkpage/layouts/partials/event-card.html
+++ b/themes/linkpage/layouts/partials/event-card.html
@@ -25,6 +25,14 @@
             Route
         </a>
         {{ end }}
+        {{ with $event.info_url }}
+        <a href="{{ . | relURL }}" class="route-button" data-goatcounter-click="{{ with urls.Parse $site.BaseURL }}{{ .Host }}{{ end }}-{{ $event.title | urlize }}-info-{{ . }}">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                <path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/>
+            </svg>
+            {{ $event.info_label | default "More Info" }}
+        </a>
+        {{ end }}
         <button class="share-button" data-event-title="{{ $event.title }}" data-event-date="{{ $event.date }}" data-event-url="{{ $event.url }}" data-goatcounter-click="{{ with urls.Parse $site.BaseURL }}{{ .Host }}{{ end }}-{{ $event.title | urlize }}-event-copy-ext-{{ $event.url }}" aria-label="Share event">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                 <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/>

--- a/themes/linkpage/static/css/style.css
+++ b/themes/linkpage/static/css/style.css
@@ -744,6 +744,7 @@ hr {
 
 .event-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
     flex-shrink: 0;
 }
@@ -1026,7 +1027,7 @@ hr {
 
     .event-button,
     .route-button {
-        flex: 1;
+        flex: 1 1 calc(50% - 0.25rem);
     }
 
     .share-button,


### PR DESCRIPTION
## Summary

- Couldn't push directly to `add-giveaway-rules` on `redfishingboat/ridewestside` (fork not authorized in this session), so this opens a fresh PR against `main` instead, per the task's fallback instruction.
- Pulls in the new giveaway rules page added in #35 (`content/events/BeavertonMuralsPublicArt/index.md`) unchanged.
- Adds it as a **"Photo Giveaway"** button on the existing `8/23 Beaverton Murals and Public Art Ride` event card, via a new optional `info_url` / `info_label` pair on event entries (mirrors the existing `route` button pattern in `event-card.html`).
- Documents the new fields in `CLAUDE.md`'s Event Fields table.

## Test plan

- [x] `go run ./cmd/generate-events && hugo --gc --minify` builds cleanly
- [x] Verified `/events/beavertonmuralspublicart/` renders the giveaway rules content
- [x] Verified the homepage event card for the 8/23 ride renders a "Photo Giveaway" button linking to that page


---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXPVCV7oD6uazDJWMw3VR)_