### PR TITLE
Add Bike Bus to Orenco Elementary Back to School Night

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Tags appear as clickable chips on each event card and populate the Tag filter dr
 | `happy-hour` | Bike Happy Hour social event |
 | `ride` | Group ride |
 | `r2r` | Ride to Ride — the group rides to attend another event |
+| `bike-bus` | A group ride escorting riders (often families/students) to a specific destination event |
 | `not-rws` | Not a Ride Westside event; listed for community awareness |
 | `cause` | Charity or cause-related ride |
 | `festival` | Cycling festival or community event |

--- a/content/events.md
+++ b/content/events.md
@@ -329,6 +329,15 @@ events:
     info_url: "/events/beavertonmuralspublicart/"
     info_label: "Photo Giveaway"
 
+  - title: "9/18 Bike Bus to Orenco Elementary Back to School Night"
+    date: "September 18, 2026"
+    url: "https://www.shift2bikes.org/calendar/event-24775"
+    start: "Orenco"
+    end: "Orenco"
+    start_address: "6420 NE Oelrich St, Hillsboro, OR 97124"
+    start_time: "5:00 PM"
+    tags: [ride, r2r, family-friendly]
+
 recurring:
   # Beaverton Bike Happy Hours - 2nd and 4th Monday
   - title: "Bike Happy Hour"

--- a/content/events.md
+++ b/content/events.md
@@ -336,7 +336,7 @@ events:
     end: "Orenco"
     start_address: "6420 NE Oelrich St, Hillsboro, OR 97124"
     start_time: "5:00 PM"
-    tags: [ride, r2r, family-friendly]
+    tags: [ride, bike-bus, r2r, family-friendly]
 
 recurring:
   # Beaverton Bike Happy Hours - 2nd and 4th Monday


### PR DESCRIPTION
## Summary

- Adds a one-off event to `content/events.md`'s `# Rides` section: **Bike Bus to Orenco Elementary Back to School Night**, Friday, September 18, 2026, 5:00 PM.
- Meet at Orenco Presbyterian Church (6420 NE Oelrich St, Hillsboro, OR 97124), bikes gather on the grass between the church and community garden. Meet at 5, roll at 5:30. ~1.5 mi loop with minimal elevation change to Orenco Elementary's Back to School Open House, returning to the church lot afterward. Ride Westside is providing sound and corking.
- `start`/`end` set to `"Orenco"` (matching the existing Orenco/Quatama neighborhood convention already used elsewhere in the file), `start_time: "5:00 PM"` for the timed calendar entry, `tags: [ride, r2r, family-friendly]` (matching the tagging convention used on the other existing Bike Bus entries in the file).
- `url` uses the canonical `shift2bikes.org/calendar/event-24775` form (extracted event ID) so it matches the pattern `checkLinks` validates against via the Shift2Bikes API, rather than the long-form event page URL that was originally shared.

## Test plan

- [x] `go run ./cmd/generate-events && hugo --gc --minify` builds cleanly
- [x] Verified the new event card renders on the homepage with correct date, location, tags, and "View Event" link
- [x] Verified `calendar.ics` includes a correctly timed entry (Sept 18 5:00 PM Pacific → `DTSTART:20260919T000000Z`), consistent with how existing timed Bike Bus entries convert


---
_Generated by [Claude Code](https://claude.ai/code/session_01GoXPVCV7oD6uazDJWMw3VR)_